### PR TITLE
read: scaffold *InputPartitionReader* + contexts

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/InputPartitionContext.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/InputPartitionContext.java
@@ -1,0 +1,24 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import java.io.Serializable;
+
+public interface InputPartitionContext<T> extends Serializable {
+
+  InputPartitionReaderContext<T> createPartitionReaderContext();
+
+  boolean supportsColumnarReads();
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/InputPartitionReaderContext.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/InputPartitionReaderContext.java
@@ -1,0 +1,25 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface InputPartitionReaderContext<T> extends Closeable {
+
+  boolean next() throws IOException;
+
+  T get();
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInputPartitionContext.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInputPartitionContext.java
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import com.google.cloud.spanner.BatchReadOnlyTransaction;
+import com.google.cloud.spanner.Partition;
+import org.apache.spark.sql.catalyst.InternalRow;
+
+public class SpannerInputPartitionContext implements InputPartitionContext<InternalRow> {
+
+  private BatchReadOnlyTransaction txn;
+  private Partition partition;
+
+  public SpannerInputPartitionContext(BatchReadOnlyTransaction txn, Partition partition) {
+    this.partition = partition;
+    this.txn = txn;
+  }
+
+  @Override
+  public InputPartitionReaderContext<InternalRow> createPartitionReaderContext() {
+    return new SpannerInputPartitionReaderContext(this.txn, this.txn.execute(this.partition));
+  }
+
+  @Override
+  public boolean supportsColumnarReads() {
+    return false;
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInputPartitionReaderContext.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInputPartitionReaderContext.java
@@ -1,0 +1,48 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import com.google.cloud.spanner.BatchReadOnlyTransaction;
+import com.google.cloud.spanner.ResultSet;
+import java.io.IOException;
+import org.apache.spark.sql.catalyst.InternalRow;
+
+public class SpannerInputPartitionReaderContext
+    implements InputPartitionReaderContext<InternalRow> {
+
+  private BatchReadOnlyTransaction txn;
+  private ResultSet rs;
+
+  public SpannerInputPartitionReaderContext(BatchReadOnlyTransaction txn, ResultSet rs) {
+    this.txn = txn;
+    this.rs = rs;
+  }
+
+  @Override
+  public boolean next() throws IOException {
+    return this.rs.next();
+  }
+
+  @Override
+  public InternalRow get() {
+    return SpannerUtils.resultSetRowToInternalRow(this.rs);
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.rs.close();
+    this.txn.close();
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerPartitionReader.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerPartitionReader.java
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import java.io.IOException;
+import org.apache.spark.sql.connector.read.PartitionReader;
+
+public class SpannerPartitionReader<T> implements PartitionReader<T> {
+
+  private InputPartitionReaderContext<T> context;
+
+  public SpannerPartitionReader(InputPartitionReaderContext<T> context) {
+    this.context = context;
+  }
+
+  @Override
+  public boolean next() throws IOException {
+    return this.context.next();
+  }
+
+  @Override
+  public T get() {
+    return this.context.get();
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.context.close();
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerUtils.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerUtils.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
 
 public class SpannerUtils {
 
@@ -73,6 +74,12 @@ public class SpannerUtils {
       rows.add(resultSetRowToSparkRow(rs));
     }
     return rows;
+  }
+
+  public static InternalRow resultSetRowToInternalRow(ResultSet rs) {
+    // TODO: Implement me.
+    // See https://github.com/GoogleCloudDataproc/spark-spanner-connector/issues/54
+    return null;
   }
 
   public static Row resultSetRowToSparkRow(ResultSet rs) {


### PR DESCRIPTION
This change begins the ground work to fully implement PartitionReader so that .show() can fully work.

Updates #54