### PR TITLE
read: plumb Spanner*Partition

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInputPartition.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInputPartition.java
@@ -1,0 +1,31 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import org.apache.spark.sql.connector.read.InputPartition;
+
+public class SpannerInputPartition implements InputPartition {
+
+  private static final long serialVersionUID = -1628086285225555459L;
+  InputPartitionContext ctx;
+
+  public SpannerInputPartition(InputPartitionContext ctx) {
+    this.ctx = ctx;
+  }
+
+  public InputPartitionContext getContext() {
+    return this.ctx;
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerPartition.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerPartition.java
@@ -1,0 +1,37 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import org.apache.spark.Partition;
+
+public class SpannerPartition implements Partition {
+
+  private final String stream;
+  private final int index;
+
+  public SpannerPartition(String stream, int index) {
+    this.index = index;
+    this.stream = stream;
+  }
+
+  public String getStream() {
+    return this.stream;
+  }
+
+  @Override
+  public int index() {
+    return this.index;
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerPartitionReaderFactory.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerPartitionReaderFactory.java
@@ -40,7 +40,7 @@ public class SpannerPartitionReaderFactory implements PartitionReaderFactory {
 
   @Override
   public PartitionReader<InternalRow> createReader(InputPartition partition) {
-    // TODO: Fill me in.
-    return null;
+    InputPartitionContext<InternalRow> ctx = ((SpannerInputPartition) partition).getContext();
+    return new SpannerPartitionReader<>(ctx.createPartitionReaderContext());
   }
 }


### PR DESCRIPTION
This change adds new classes:
* SpannerInputPartion
* SpannerPartition

which will receive partitioned reads and then convert them into a PartitionReader. SpannerPartition is serializable and sendable over the wire.

Updates #54