### PR TITLE
dependencies: upgrade Apache Commons Compress after CVE-2023-42503

### DIFF
--- a/spark-spanner-parent/pom.xml
+++ b/spark-spanner-parent/pom.xml
@@ -253,7 +253,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.22</version>
+                <version>1.24.0</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
Upgrades our libraries to mitigate CVE-2023-42503

Supersedes PR #66