### PR TITLE
SpannerTable: declare correct capabilities

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerTable.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerTable.java
@@ -39,11 +39,7 @@ public class SpannerTable implements Table, SupportsRead {
   private String tableName;
   private StructType tableSchema;
   private static final ImmutableSet<TableCapability> tableCapabilities =
-      ImmutableSet.of(
-          TableCapability.BATCH_READ,
-          TableCapability.BATCH_WRITE,
-          TableCapability.CONTINUOUS_READ,
-          TableCapability.TRUNCATE);
+      ImmutableSet.of(TableCapability.BATCH_READ);
 
   private static final Logger log = LoggerFactory.getLogger(SpannerTable.class);
 


### PR DESCRIPTION
We only correctly support BATCH_READ as this integration is firstly for just reading data from Cloud Spanner into Apache Spark.