### PR TITLE
tests: make singleton creation of Spanner + teardown

### DIFF
--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -31,17 +31,12 @@ case $STEP in
   integrationtest-real-spanner)
     # Starts the Spanner emulator and setup the gcloud command.
     # Sets the env used in the integration test.
-    $MVN test -Dtest=SpannerTableTest
-    $MVN test -Dtest=SpannerScanBuilderTest
-    $MVN test -Dtest=SpannerInputPartitionReaderContextTest
-    $MVN test -Dtest=SparkFilterUtilsTest
-    $MVN test -Dtest=ReadIntegrationTestBase
-    $MVN test -Dtest=WriteIntegrationTestBase
+    $MVN test -T 1C "-Dtest=SpannerTableTest,SpannerScanBuilderTest,SpannerInputPartitionReaderContextTest,SparkFilterUtilsTest,ReadIntegrationTestBase,WriteIntegrationTestBase"
     ;;
 
   acceptance-test)
-    $MVN test -Dtest=DataprocImage20AcceptanceTest
-    $MVN test -Dtest=DataprocImage21AcceptanceTest
+    $MVN test -T 1C -Dtest=DataprocImage20AcceptanceTest
+    $MVN test -T 1C -Dtest=DataprocImage21AcceptanceTest
     ;;
 
   *)

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/acceptance/DataprocServerlessAcceptanceTestBase.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/acceptance/DataprocServerlessAcceptanceTestBase.java
@@ -62,10 +62,17 @@ public class DataprocServerlessAcceptanceTestBase {
       Preconditions.checkNotNull(
           System.getenv("GOOGLE_CLOUD_PROJECT"),
           "Please set the 'GOOGLE_CLOUD_PROJECT' environment variable");
+
+  // It is imperative that we generate a unique databaseId since in
+  // the teardown we delete the Cloud Spanner database, hence use
+  // system time.Nanos to avoid any cross-pollution between concurrently
+  // running tests.
   private static final String DATABASE_ID =
       Preconditions.checkNotNull(
-          System.getenv("SPANNER_DATABASE_ID"),
-          "Please set the 'SPANNER_DATABASE_ID' environment variable");
+              System.getenv("SPANNER_DATABASE_ID"),
+              "Please set the 'SPANNER_DATABASE_ID' environment variable")
+          + "-"
+          + System.nanoTime();
   private static final String INSTANCE_ID =
       Preconditions.checkNotNull(
           System.getenv("SPANNER_INSTANCE_ID"),


### PR DESCRIPTION
This makes it possible to run all the tests with one database/instance and then tear down once instead of multiple times which speeds up the tests. While here, also created a unique name per instance, that'll get torn down once and for all.

Updates #99