### PR TITLE
tests: manually close our readers

### DIFF
--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerInputPartitionReaderContextTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerInputPartitionReaderContextTest.java
@@ -148,6 +148,16 @@ public class SpannerInputPartitionReaderContextTest extends SpannerTestBase {
           InternalRow row = ir.get();
           gotRows.add(row);
         }
+        SpannerPartitionReader sr = ((SpannerPartitionReader) ir);
+        sr.close();
+      } catch (IOException e) {
+      }
+    }
+
+    if (prf instanceof SpannerInputPartitionReaderContext) {
+      try {
+        SpannerInputPartitionReaderContext spc = ((SpannerInputPartitionReaderContext) prf);
+        spc.close();
       } catch (IOException e) {
       }
     }

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerScanBuilderTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerScanBuilderTest.java
@@ -83,6 +83,16 @@ public class SpannerScanBuilderTest extends SpannerTestBase {
         while (ir.next()) {
           al.add(ir.get());
         }
+        SpannerPartitionReader sr = ((SpannerPartitionReader) ir);
+        sr.close();
+      } catch (IOException e) {
+      }
+    }
+
+    if (prf instanceof SpannerInputPartitionReaderContext) {
+      try {
+        SpannerInputPartitionReaderContext spc = ((SpannerInputPartitionReaderContext) prf);
+        spc.close();
       } catch (IOException e) {
       }
     }


### PR DESCRIPTION
In our tests we manually create readers meanwhile in Spark the mechanisms exist. This change manually close the respective SpannerPartitionReader and SpannerInputPartitionReaderContext values.