### PR TITLE
Setup the retry setting when querying Spanner Java library

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerScanner.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerScanner.java
@@ -45,7 +45,7 @@ public class SpannerScanner implements Batch, Scan {
   private String[] requiredColumns;
   private Map<String, String> opts;
   private static final Logger log = LoggerFactory.getLogger(SpannerScanner.class);
-  private static final Timestamp INIT_TIME = Timestamp.now();
+  private final Timestamp INIT_TIME = Timestamp.now();
 
   public SpannerScanner(Map<String, String> opts) {
     this.opts = opts;

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerUtils.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerUtils.java
@@ -54,10 +54,14 @@ import org.threeten.bp.Duration;
 public class SpannerUtils {
   private static final RetrySettings RETRY_SETTING =
       RetrySettings.newBuilder()
-          .setInitialRetryDelay(Duration.ofMillis(500))
-          .setMaxRetryDelay(Duration.ofSeconds(16))
+          .setInitialRpcTimeout(Duration.ofHours(2))
+          .setMaxRpcTimeout(Duration.ofHours(2))
+          .setTotalTimeout(Duration.ofHours(2))
+          .setRpcTimeoutMultiplier(1.0)
+          .setInitialRetryDelay(Duration.ofSeconds(2))
+          .setMaxRetryDelay(Duration.ofSeconds(60))
           .setRetryDelayMultiplier(1.5)
-          .setMaxAttempts(5)
+          .setMaxAttempts(100)
           .build();
   private static final ObjectMapper jsonMapper = new ObjectMapper();
 
@@ -96,7 +100,7 @@ public class SpannerUtils {
             .setHeaderProvider(FixedHeaderProvider.create("user-agent", USER_AGENT));
     builder
         .getSpannerStubSettingsBuilder()
-        .executeSqlSettings()
+        .executeStreamingSqlSettings()
         .setRetryableCodes(
             Code.UNAVAILABLE, Code.RESOURCE_EXHAUSTED, Code.INTERNAL, Code.DEADLINE_EXCEEDED)
         .setRetrySettings(RETRY_SETTING);
@@ -119,6 +123,7 @@ public class SpannerUtils {
     if (emulatorHost != null) {
       builder = builder.setEmulatorHost(emulatorHost);
     }
+    System.setProperty("com.google.cloud.spanner.watchdogTimeoutSeconds", "7200");
 
     SpannerOptions options = builder.build();
     Spanner spanner = options.getService();

--- a/spark-spanner-parent/pom.xml
+++ b/spark-spanner-parent/pom.xml
@@ -55,7 +55,7 @@
         <arrow.version>12.0.0</arrow.version>
         <gax.version>2.30.0</gax.version>
         <google-cloud-dataproc.version>4.11.0</google-cloud-dataproc.version>
-        <google-cloud-spanner.version>6.43.1</google-cloud-spanner.version>  
+        <google-cloud-spanner.version>6.50.0</google-cloud-spanner.version>  
         <google-cloud-storage.version>2.20.2</google-cloud-storage.version>
         <google-truth.version>1.1.3</google-truth.version>
         <grpc.version>1.55.1</grpc.version>


### PR DESCRIPTION
- Made the retry setting sync with current dataflow setting. 
- [Updated the Spanner Java library. The newer version handles the backoff retry with respect to the RetrySetting.