### PR TITLE
Support OpenLineage

### DIFF
--- a/spark-3.1-spanner-lib/pom.xml
+++ b/spark-3.1-spanner-lib/pom.xml
@@ -42,6 +42,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.10.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/OpenLineageIntegrationTestBase.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/OpenLineageIntegrationTestBase.java
@@ -1,0 +1,121 @@
+package com.google.cloud.spark.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.openlineage.spark.agent.OpenLineageSparkListener;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+
+public class OpenLineageIntegrationTestBase extends SpannerTestBase {
+
+  @ClassRule public static OLSparkFactory sparkFactory = new OLSparkFactory();
+
+  protected SparkSession spark;
+  protected File lineageOutputFile;
+
+  protected Map<String, String> connectionProperties;
+
+  public OpenLineageIntegrationTestBase() {
+    this.spark = sparkFactory.spark;
+    this.lineageOutputFile = sparkFactory.lineageOutputFile;
+    this.connectionProperties = connectionProperties();
+  }
+
+  protected static class OLSparkFactory extends ExternalResource {
+    SparkSession spark;
+
+    File lineageOutputFile;
+
+    @Override
+    protected void before() throws Throwable {
+      lineageOutputFile = File.createTempFile("openlineage_test_" + System.nanoTime(), ".log");
+      lineageOutputFile.deleteOnExit();
+      spark =
+          SparkSession.builder()
+              .master("local")
+              .config("spark.ui.enabled", "false")
+              .config("spark.default.parallelism", 20)
+              .config("spark.extraListeners", OpenLineageSparkListener.class.getCanonicalName())
+              .config("spark.openlineage.transport.type", "file")
+              .config("spark.openlineage.transport.location", lineageOutputFile.getAbsolutePath())
+              .getOrCreate();
+      spark.sparkContext().setLogLevel("WARN");
+    }
+  }
+
+  public Dataset<Row> readFromTable(String table) {
+    Map<String, String> props = this.connectionProperties();
+    return spark
+        .read()
+        .format("cloud-spanner")
+        .option("viewsEnabled", true)
+        .option("projectId", props.get("projectId"))
+        .option("instanceId", props.get("instanceId"))
+        .option("databaseId", props.get("databaseId"))
+        .option("emulatorHost", props.get("emulatorHost"))
+        .option("table", table)
+        .load();
+  }
+
+  @Test
+  public void testOpenLineageEvents() throws Exception {
+    File outputCsv = File.createTempFile("output_" + System.nanoTime(), ".csv");
+    outputCsv.deleteOnExit();
+    Dataset<Row> df = readFromTable("compositeTable");
+    df.createOrReplaceTempView("tempview");
+    Dataset<Row> outputDf =
+        spark.sql(
+            "SELECT word, count(*) AS count FROM (SELECT explode(split(C, ' ')) AS word FROM tempview) GROUP BY 1");
+
+    outputDf
+        .coalesce(1)
+        .write()
+        .format("csv")
+        .mode(SaveMode.Overwrite)
+        .save("file://" + outputCsv.getPath());
+
+    List<JsonObject> jsonObjects = parseEventLog(lineageOutputFile);
+    assertThat(jsonObjects).isNotEmpty();
+
+    jsonObjects.forEach(
+        jsonObject -> {
+          JsonObject input = jsonObject.getAsJsonArray("inputs").get(0).getAsJsonObject();
+          assertThat(input.get("namespace").getAsString())
+              .isEqualTo(
+                  String.format(
+                      "spanner://%s/%s",
+                      connectionProperties.get("projectId"),
+                      connectionProperties.get("instanceId")));
+          assertThat(input.get("name").getAsString())
+              .isEqualTo(
+                  String.format("%s/%s", connectionProperties.get("databaseId"), "compositeTable"));
+        });
+  }
+
+  private List<JsonObject> parseEventLog(File file) throws Exception {
+    List<JsonObject> eventList;
+    try (Scanner scanner = new Scanner(file)) {
+      eventList = new ArrayList<>();
+      while (scanner.hasNextLine()) {
+        String line = scanner.nextLine();
+        JsonObject event = JsonParser.parseString(line).getAsJsonObject();
+        if (!event.getAsJsonArray("inputs").isEmpty()) {
+          eventList.add(event);
+        }
+      }
+    }
+    return eventList;
+  }
+}

--- a/spark-spanner-parent/pom.xml
+++ b/spark-spanner-parent/pom.xml
@@ -65,6 +65,7 @@
         <paranamer.version>2.8</paranamer.version>
         <protobuf.version>3.23.0</protobuf.version>
         <zstd.version>1.4.9-1</zstd.version>
+        <openlineage.version>1.19.0</openlineage.version>
         <deploy.skip>true</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
@@ -288,6 +289,12 @@
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.openlineage</groupId>
+            <artifactId>openlineage-spark_2.12</artifactId>
+            <version>${openlineage.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR introduces OpenLineage support to the `spark-spanner-connector`. The following changes and enhancements have been made:

* Integration with OpenLineage: Implemented `Table's` `properties()` method, as it's a source of input dataset's name and namespace information in `openlineage-spark` integration
* Metadata Enrichment: Enhanced the connector to publish detailed lineage information, including datasets and operation facets.
* Compatibility: Ensured compatibility with existing Spark jobs using the connector, allowing seamless lineage tracking without requiring significant modifications.

### Key Benefits:
* Improved Visibility: Provides enhanced visibility into data flow and transformations within Spark jobs using the Spanner connector.
* Facilitates Auditing and Compliance: Helps in tracking data lineage, aiding in auditing and compliance efforts.
* Eases Debugging and Monitoring: Simplifies debugging and monitoring of data pipelines by providing detailed lineage information.
Please review the changes and provide feedback. Your input is valuable in ensuring the robustness and utility of this integration.