### PR TITLE
fix: prefix column names with table name to avoid ambiguity

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerScanner.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerScanner.java
@@ -90,9 +90,13 @@ public class SpannerScanner implements Batch, Scan {
     if (this.requiredColumns != null && this.requiredColumns.size() > 0) {
       // Prefix each column with the table name to avoid ambiguity when column name
       // matches table name
+      boolean isPostgreSql = batchClient.databaseClient.getDialect().equals(Dialect.POSTGRESQL);
+      String tableName = this.spannerTable.name();
+      String quotedTableName = isPostgreSql ? "\"" + tableName + "\"" : "`" + tableName + "`";
       String columnsWithTablePrefix =
           this.requiredColumns.stream()
-              .map(col -> this.spannerTable.name() + "." + col)
+              .map(col -> isPostgreSql ? "\"" + col + "\"" : "`" + col + "`")
+              .map(quotedCol -> quotedTableName + "." + quotedCol)
               .collect(Collectors.joining(", "));
       selectPrefix = "SELECT " + columnsWithTablePrefix;
     }

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerScanner.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerScanner.java
@@ -88,7 +88,13 @@ public class SpannerScanner implements Batch, Scan {
     // 1. Use * if no requiredColumns were requested else select them.
     String selectPrefix = "SELECT *";
     if (this.requiredColumns != null && this.requiredColumns.size() > 0) {
-      selectPrefix = "SELECT " + String.join(", ", this.requiredColumns);
+      // Prefix each column with the table name to avoid ambiguity when column name
+      // matches table name
+      String columnsWithTablePrefix =
+          this.requiredColumns.stream()
+              .map(col -> this.spannerTable.name() + "." + col)
+              .collect(Collectors.joining(", "));
+      selectPrefix = "SELECT " + columnsWithTablePrefix;
     }
     String sqlStmt = selectPrefix + " FROM " + this.spannerTable.name();
     if (this.filters.length > 0) {

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerScannerTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerScannerTest.java
@@ -1,0 +1,82 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for SpannerScanner.buildColumnsWithTablePrefix() */
+@RunWith(JUnit4.class)
+public class SpannerScannerTest {
+
+  @Test
+  public void testBuildColumnsWithTablePrefix_googleSql_singleColumn() {
+    Set<String> columns = new HashSet<>(Arrays.asList("id"));
+    String result = SpannerScanner.buildColumnsWithTablePrefix("users", columns, false);
+    assertThat(result).isEqualTo("`users`.`id`");
+  }
+
+  @Test
+  public void testBuildColumnsWithTablePrefix_googleSql_multipleColumns() {
+    Set<String> columns = new HashSet<>(Arrays.asList("id", "name"));
+    String result = SpannerScanner.buildColumnsWithTablePrefix("users", columns, false);
+    assertThat(result).contains("`users`.`id`");
+    assertThat(result).contains("`users`.`name`");
+  }
+
+  @Test
+  public void testBuildColumnsWithTablePrefix_googleSql_columnMatchingTableName() {
+    Set<String> columns = new HashSet<>(Arrays.asList("users", "id"));
+    String result = SpannerScanner.buildColumnsWithTablePrefix("users", columns, false);
+    assertThat(result).contains("`users`.`users`");
+    assertThat(result).contains("`users`.`id`");
+  }
+
+  @Test
+  public void testBuildColumnsWithTablePrefix_postgreSql_singleColumn() {
+    Set<String> columns = new HashSet<>(Arrays.asList("id"));
+    String result = SpannerScanner.buildColumnsWithTablePrefix("users", columns, true);
+    assertThat(result).isEqualTo("\"users\".\"id\"");
+  }
+
+  @Test
+  public void testBuildColumnsWithTablePrefix_postgreSql_multipleColumns() {
+    Set<String> columns = new HashSet<>(Arrays.asList("id", "name"));
+    String result = SpannerScanner.buildColumnsWithTablePrefix("users", columns, true);
+    assertThat(result).contains("\"users\".\"id\"");
+    assertThat(result).contains("\"users\".\"name\"");
+  }
+
+  @Test
+  public void testBuildColumnsWithTablePrefix_postgreSql_columnMatchingTableName() {
+    Set<String> columns = new HashSet<>(Arrays.asList("users", "id"));
+    String result = SpannerScanner.buildColumnsWithTablePrefix("users", columns, true);
+    assertThat(result).contains("\"users\".\"users\"");
+    assertThat(result).contains("\"users\".\"id\"");
+  }
+
+  @Test
+  public void testBuildColumnsWithTablePrefix_emptyColumns() {
+    Set<String> columns = new HashSet<>();
+    String result = SpannerScanner.buildColumnsWithTablePrefix("users", columns, false);
+    assertThat(result).isEmpty();
+  }
+}


### PR DESCRIPTION
Queries fail when a column name matches the table name, causing Spanner to interpret the reference as a struct:

```
StatusRuntimeException: UNIMPLEMENTED: Unsupported query shape: 
A struct value cannot be returned as a column value.
```

Solution
* Prefix selected columns with table name in generated SQL queries.

Before: `SELECT users FROM users` ❌
After: `SELECT users.users FROM users` ✅

Changes
Modified `SpannerScanner.java` to qualify column names with table prefix