### PR TITLE
Add GitHub Workflow to build and publish JARs as artifacts

### DIFF
--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -1,4 +1,3 @@
-
 name: Build and Verify
 on:
   push:
@@ -7,11 +6,8 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-spark-31:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        spark-version: ['3.1', '3.2', '3.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +23,61 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Spark ${{ matrix.spark-version }}
+      - name: Build with Spark 3.1
         run: |
-          mvn -B -e install -P${{ matrix.spark-version }} -DskipTests
+          mvn -B -e install -P3.1 -DskipTests
+      - name: Upload Maven repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+  build-spark-32:
+    needs: build-spark-31
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+      - name: Build with Spark 3.2
+        run: |
+          mvn -B -e install -P3.2 -DskipTests
+      - name: Upload Maven repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+  build-spark-33:
+    needs: build-spark-32
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+      - name: Build with Spark 3.3
+        run: |
+          mvn -B -e install -P3.3 -DskipTests
+      - name: Upload Maven repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository

--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -1,3 +1,4 @@
+
 name: Build and Verify
 on:
   push:
@@ -6,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -14,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -26,10 +27,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Start Spanner Emulator
+      - name: Build with Spark ${{ matrix.spark-version }}
         run: |
-          docker run -d -p 9010:9010 -p 9020:9020 gcr.io/cloud-spanner-emulator/emulator
-          export SPANNER_EMULATOR_HOST=localhost:9010
-      - name: Build and test with Spark ${{ matrix.spark-version }}
-        run: |
-          mvn -B -e verify -P${{ matrix.spark-version }}
+          mvn -B -e install -P${{ matrix.spark-version }} -DskipTests

--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -1,3 +1,4 @@
+
 name: Build and Verify
 on:
   push:
@@ -6,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build-spark-31:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,58 +27,9 @@ jobs:
       - name: Build with Spark 3.1
         run: |
           mvn -B -e install -P3.1 -DskipTests
-      - name: Upload Maven repository
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven-repository
-          path: ~/.m2/repository
-
-  build-spark-32:
-    needs: build-spark-31
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up JDK 8
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-      - name: Download Maven repository
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repository
-          path: ~/.m2/repository
       - name: Build with Spark 3.2
         run: |
           mvn -B -e install -P3.2 -DskipTests
-      - name: Upload Maven repository
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven-repository
-          path: ~/.m2/repository
-
-  build-spark-33:
-    needs: build-spark-32
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up JDK 8
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-      - name: Download Maven repository
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repository
-          path: ~/.m2/repository
       - name: Build with Spark 3.3
         run: |
           mvn -B -e install -P3.3 -DskipTests
-      - name: Upload Maven repository
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven-repository
-          path: ~/.m2/repository

--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -1,0 +1,35 @@
+name: Build and Verify
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        spark-version: ['3.1', '3.2', '3.3']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Start Spanner Emulator
+        run: |
+          docker run -d -p 9010:9010 -p 9020:9020 gcr.io/cloud-spanner-emulator/emulator
+          export SPANNER_EMULATOR_HOST=localhost:9010
+      - name: Build and test with Spark ${{ matrix.spark-version }}
+        run: |
+          mvn -B -e verify -P${{ matrix.spark-version }}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -23,13 +23,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Build with Spark 3.1
+      - name: Build for Spark 3.1
         run: |
           mvn -B -e install -P3.1 -DskipTests
-      - name: Build with Spark 3.2
+      - name: Build for Spark 3.2
         run: |
           mvn -B -e install -P3.2 -DskipTests
-      - name: Build with Spark 3.3
+      - name: Build for Spark 3.3
         run: |
           mvn -B -e install -P3.3 -DskipTests
       - name: Get short commit hash

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1,5 +1,4 @@
-
-name: Build and Verify
+name: Build and Publish
 on:
   push:
     branches:
@@ -33,3 +32,11 @@ jobs:
       - name: Build with Spark 3.3
         run: |
           mvn -B -e install -P3.3 -DskipTests
+      - name: Upload Shaded JARs
+        uses: actions/upload-artifact@v4
+        with:
+          name: shaded-spark-spanner-jars
+          path: |
+            spark-3.1-spanner/target/spark-3.1-spanner-*.jar
+            spark-3.2-spanner/target/spark-3.2-spanner-*.jar
+            spark-3.3-spanner/target/spark-3.3-spanner-*.jar

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -32,11 +32,20 @@ jobs:
       - name: Build with Spark 3.3
         run: |
           mvn -B -e install -P3.3 -DskipTests
+      - name: Get short commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Stage artifacts
+        run: |
+          mkdir shaded-jars
+          for file in spark-3.*/target/spark-3.*.jar; do
+            if [[ "$file" == *"lib"* || "$file" == *"original"* ]]; then
+              continue
+            fi
+            cp "$file" shaded-jars/
+          done
       - name: Upload Shaded JARs
         uses: actions/upload-artifact@v4
         with:
-          name: shaded-spark-spanner-jars
-          path: |
-            spark-3.1-spanner/target/spark-3.1-spanner-*.jar
-            spark-3.2-spanner/target/spark-3.2-spanner-*.jar
-            spark-3.3-spanner/target/spark-3.3-spanner-*.jar
+          name: shaded-spark-spanner-jars-${{ steps.vars.outputs.sha_short }}
+          path: shaded-jars/


### PR DESCRIPTION
- Connector is built sequentially for Spark 3.1, 3.2, 3.3 since that's how library dependencies are set up.
- Snapshot JARs are published as  workflow artifacts.
- Tests are not included since vast majority require GCP resources. 