### PR TITLE
Use the nexus-staging-maven-plugin, with the new endpoint

### DIFF
--- a/spark-spanner-parent/pom.xml
+++ b/spark-spanner-parent/pom.xml
@@ -828,7 +828,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
                             <skipRemoteStaging>${nexus.remote.skip}</skipRemoteStaging>
                         </configuration>
@@ -836,7 +836,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Following https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/1429, apply the same change to spark-spanner-connector.