### PR TITLE
Tooling to run connector benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ dependency-reduced-pom.xml
 
 # direnv
 .envrc
+
+# Benchmark environment-specific configuration
+benchmark/environment.json

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -175,15 +175,15 @@ This section describes how to run benchmarks using sbt tasks.
     ```
 2.  **Run a Benchmark and Establish Baseline**:
     *   Navigate to the `benchmark` directory.
-    *   Run your chosen benchmark (e.g., `dataproc-100k-records`):
+    *   Run your chosen benchmark (e.g., `dataproc-100mil-records`):
         ```bash
         cd benchmark
-        sbt "runBenchmark dataproc-100k-records"
+        sbt "runBenchmark dataproc-100mil-records"
         ```
     *   The script will print the GCS path where the result JSON was uploaded (e.g., `gs://<your-results-bucket>/SparkSpannerWriteBenchmark/<timestamp>_<githash>.json`). Note down the full GCS path.
     *   Use this path to set it as the baseline:
         ```bash
-        sbt "setBenchmarkBaseline dataproc-100k-records <full_gcs_path_from_above>"
+        sbt "setBenchmarkBaseline dataproc-100mil-records <full_gcs_path_from_above>"
         ```
     This step effectively tags a known-good performance run as your reference point.
 
@@ -197,12 +197,12 @@ This section describes how to run benchmarks using sbt tasks.
     *   Run the same benchmark again to generate new results:
         ```bash
         # Still in the benchmark directory
-        sbt "runBenchmark dataproc-100k-records"
+        sbt "runBenchmark dataproc-100mil-records"
         ```
     *   Note down the GCS path for the new run from the output.
     *   Compare the new results against your established baseline:
         ```bash
-        sbt "compareBenchmarkResults dataproc-100k-records <full_gcs_path_for_new_run>"
+        sbt "compareBenchmarkResults dataproc-100mil-records <full_gcs_path_for_new_run>"
         ```
     The task will output a formatted comparison report, showing performance deltas between your baseline and the new run.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -9,7 +9,7 @@ This guide walks through setting up your Google Cloud environment to run the Spa
 ### 1. Configure Your Environment
 
 The benchmark runner and supporting sbt tasks now use a structured configuration:
-*   **Benchmark Definitions**: Defined in `benchmark/benchmark_definitions.json`. These describe what to test.
+*   **Benchmark Definitions**: Defined in `benchmark/benchmark_definitions.json`. These describe a known tests -- combination of a Spark job, job parameters and Spark environment.
 *   **Data Sources**: Defined in `benchmark/data_sources.json`. These map logical data names to DDLs, allowing separation of schema from specific table names.
 *   **Environment Configuration**: Defined in `benchmark/environment.json`. This file contains all environment-specific settings (GCP project IDs, Dataproc cluster names, GCS bucket names, Spanner instance IDs, Databricks host/token/cluster IDs, etc.) and mappings from logical data source names to physical table names in your environment.
 
@@ -50,12 +50,12 @@ Use the provided sbt tasks to ensure the necessary Spanner instance, database, a
 ```bash
 # Ensure Spanner instance and database exist for a specific benchmark scenario.
 # This task will create the instance and database if they don't exist.
-# Example: sbt "spannerUp dataproc-100k-records"
+# Example: sbt "spannerUp dataproc-100mil-records"
 sbt "spannerUp <benchmark_name>"
 
 # Create the Spanner table required for a specific benchmark scenario.
 # This task uses the DDL defined in `data_sources.json` for the given benchmark.
-# Example: sbt "createBenchmarkSpannerTable dataproc-100k-records"
+# Example: sbt "createBenchmarkSpannerTable dataproc-100mil-records"
 sbt "createBenchmarkSpannerTable <benchmark_name>"
 ```
 *Note: The `createBenchmarkSpannerTable` task will infer the DDL file from `data_sources.json` based on the benchmark's `dataSource` and automatically replace the placeholder table name with the `writeTable` value derived from your benchmark configuration.*

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -25,6 +25,12 @@ You need to create and configure your local `environment.json` file:
 
 **Important**: `benchmark/environment.json` is in `.gitignore` and should **not** be committed to the repository.
 
+**Databricks Token Refresh**: Databricks tokens can expire. You can refresh the `databricksToken` in your `environment.json` file automatically using the sbt task:
+```bash
+sbt refreshDatabricksToken
+```
+This task will create a new temporary token via the Databricks CLI and update your `environment.json`. Ensure your Databricks CLI is configured and has permissions to create new tokens.
+
 ### 2. Set up Your GCP Project
 
 Make sure you have the Google Cloud SDK (`gcloud`) installed and authenticated.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -228,13 +228,13 @@ Each JSON file contains detailed information about the run, including performanc
 
 ### "Error: Catalog 'X' is not accessible in current workspace"
 
-This error indicates a mismatch between the Databricks workspace targeted by your CLI configuration and the one specified in `benchmarkDatabricks.json`, or a lack of proper permissions.
+This error indicates a mismatch between the Databricks workspace targeted by your CLI configuration and the one specified in `environment.json`, or a lack of proper permissions.
 
 **Possible Causes and Solutions:**
 
 1.  **Workspace Host Mismatch**:
-    *   **Diagnosis**: Your `databricks auth describe` command might show a different `Host` than the `databricksHost` value in your `benchmarkDatabricks.json`. The `sbt` task uses the host from `benchmarkDatabricks.json`.
-    *   **Solution**: Update the `databricksHost` in `benchmarkDatabricks.json` to match the host of the Databricks workspace where your Unity Catalog is correctly configured and accessible. Ensure all other Databricks-specific settings (`clusterId`, `ucVolumePath`) are valid for this workspace.
+    *   **Diagnosis**: Your `databricks auth describe` command might show a different `Host` than the `databricksHost` value in your `environment.json`. The `sbt` task uses the host from `environment.json`.
+    *   **Solution**: Update the `databricksHost` in `environment.json` to match the host of the Databricks workspace where your Unity Catalog is correctly configured and accessible. Ensure all other Databricks-specific settings (`clusterId`, `ucVolumePath`) are valid for this workspace.
 
 2.  **Insufficient Permissions**: Even if the catalog is bound to the workspace, the user or service principal associated with your `databricksToken` might lack the necessary permissions.
     *   **Diagnosis**:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,246 @@
+# Spark Spanner Connector Benchmark
+
+This benchmark is designed to test the performance of the Spark Spanner Connector, particularly for write operations. It can be run on Google Cloud Dataproc.
+
+## Getting Started
+
+This guide walks through setting up your Google Cloud environment to run the Spark Spanner Connector benchmarks.
+
+### 1. Configure Your Environment
+
+The benchmark runner and supporting sbt tasks now use a structured configuration:
+*   **Benchmark Definitions**: Defined in `benchmark/benchmark_definitions.json`. These describe what to test.
+*   **Data Sources**: Defined in `benchmark/data_sources.json`. These map logical data names to DDLs, allowing separation of schema from specific table names.
+*   **Environment Configuration**: Defined in `benchmark/environment.json`. This file contains all environment-specific settings (GCP project IDs, Dataproc cluster names, GCS bucket names, Spanner instance IDs, Databricks host/token/cluster IDs, etc.) and mappings from logical data source names to physical table names in your environment.
+
+You need to create and configure your local `environment.json` file:
+
+1.  Copy the template:
+    ```bash
+    cp benchmark/environment.json.template benchmark/environment.json
+    ```
+2.  Open `benchmark/environment.json` in your editor and fill in the values for the `dataproc` or `databricks` sections with your specific details.
+
+**Important for Databricks GCS Access**: If running benchmarks on Databricks and writing results to GCS, ensure that the `application_default_credentials.json` file is provisioned to each worker node's filesystem at `/root/.config/gcloud/application_default_credentials.json`. The benchmark notebook expects this file to be present at that exact location.
+
+**Important**: `benchmark/environment.json` is in `.gitignore` and should **not** be committed to the repository.
+
+### 2. Set up Your GCP Project
+
+Make sure you have the Google Cloud SDK (`gcloud`) installed and authenticated.
+
+```bash
+# Set your project ID
+gcloud config set project your-gcp-project-id
+
+# Set your region (matching spannerRegion)
+gcloud config set compute/region your-gcp-region
+```
+
+You'll also need to enable the Spanner and Dataproc APIs:
+```bash
+gcloud services enable spanner.googleapis.com
+gcloud services enable dataproc.googleapis.com
+```
+
+### 3. Create Spanner Resources
+
+Use the provided sbt tasks to ensure the necessary Spanner instance, database, and table exist for your benchmark run. These tasks read their configuration (project ID, instance ID, database ID, etc.) from the `environment.json` file.
+
+```bash
+# Ensure Spanner instance and database exist for a specific benchmark scenario.
+# This task will create the instance and database if they don't exist.
+# Example: sbt "spannerUp dataproc-100k-records"
+sbt "spannerUp <benchmark_name>"
+
+# Create the Spanner table required for a specific benchmark scenario.
+# This task uses the DDL defined in `data_sources.json` for the given benchmark.
+# Example: sbt "createBenchmarkSpannerTable dataproc-100k-records"
+sbt "createBenchmarkSpannerTable <benchmark_name>"
+```
+*Note: The `createBenchmarkSpannerTable` task will infer the DDL file from `data_sources.json` based on the benchmark's `dataSource` and automatically replace the placeholder table name with the `writeTable` value derived from your benchmark configuration.*
+
+### 4. Create GCS Buckets
+
+The benchmark requires two GCS buckets:
+*   A staging bucket for Dataproc.
+*   A bucket to store benchmark results.
+
+You can create the results bucket using the `createResultsBucket` sbt task. You'll need to create the Dataproc staging bucket manually.
+
+```bash
+# Create the Dataproc staging bucket
+gsutil mb -p your-gcp-project-id -l your-gcp-region gs://your-dataproc-staging-bucket/
+
+# Create the GCS bucket for benchmark results
+sbt createResultsBucket
+```
+
+### 5. Service Account and Permissions
+
+The benchmarks run on Dataproc and authenticate to Spanner using the VM's service account. This service account needs permissions to access Spanner and GCS.
+
+By default, Dataproc clusters use the project's default Compute Engine service account. For simplicity, you can grant this service account the required roles.
+
+```bash
+# Get your project number
+PROJECT_NUMBER=$(gcloud projects describe your-gcp-project-id --format="value(projectNumber)")
+
+# Get your default Compute Engine service account email
+SERVICE_ACCOUNT_EMAIL="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+
+# Grant roles
+# These roles are generally sufficient for the benchmark to run.
+gcloud projects add-iam-policy-binding your-gcp-project-id --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/spanner.databaseUser"
+gcloud projects add-iam-policy-binding your-gcp-project-id --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/spanner.databaseAdmin"
+gcloud projects add-iam-policy-binding your-gcp-project-id --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" --role="roles/storage.objectAdmin"
+```
+
+## Prerequisites
+
+Before you begin, make sure you have the following tools installed:
+- Java (version 8 or higher)
+- Apache Maven
+- sbt (Scala Build Tool)
+- Google Cloud SDK (`gcloud`)
+- `jq` (a lightweight and flexible command-line JSON processor)
+
+## Authentication
+
+The benchmark handles authentication differently depending on the environment:
+
+### Google Cloud Dataproc
+
+On Google Cloud Dataproc, the benchmark authenticates to Google Cloud Spanner using the service account of the cluster's VM instances.
+When the Dataproc cluster is created, it should be configured with appropriate scopes (e.g., `https://www.googleapis.com/auth/cloud-platform`).
+As long as the cluster's service account has the necessary IAM permissions for Spanner (e.g., `roles/spanner.databaseUser`) and GCS (e.g., `roles/storage.objectAdmin`), no additional authentication configuration is needed within the benchmark code.
+
+### Databricks
+
+Authentication for both Google Cloud Spanner and Google Cloud Storage is handled via a single service account, provisioned to the cluster using an init script. This provides a unified and secure way to grant GCP access to your Databricks jobs.
+
+#### 1. Create a Databricks Secret
+
+First, you need to store your GCP service account's JSON key file in a Databricks secret.
+
+1.  Create a secret scope. For example, `gcp-credentials`.
+    ```bash
+    databricks secrets create-scope gcp-credentials
+    ```
+2.  Store your service account key in the scope. Let's call the secret `spanner-benchmark-sa`.
+    ```bash
+    databricks secrets put-secret gcp-credentials spanner-benchmark-sa --json-file /path/to/your/service-account.json
+    ```
+
+#### 2. Configure the Cluster Init Script
+
+The `benchmark/setup_gcp_credentials.sh` script is designed to run as a cluster-scoped init script. It reads the secret you just created and installs it as the Application Default Credentials (ADC) file on each node in the cluster.
+
+1.  **Upload the init script**: Upload `benchmark/setup_gcp_credentials.sh` to a location on your Databricks workspace or DBFS (e.g., `dbfs:/databricks/init_scripts/setup_gcp_credentials.sh`).
+2.  **Configure the cluster**: In your Databricks cluster configuration, navigate to "Advanced Options" -> "Init Scripts". Add the path to the script you just uploaded.
+3.  **Set Environment Variables**: In the same cluster configuration, under "Advanced Options" -> "Spark", set the following environment variable. This tells the init script which secret to read.
+    ```
+    GCP_CREDENTIALS={{secrets/gcp-credentials/spanner-benchmark-sa}}
+    ```
+    Replace `gcp-credentials` and `spanner-benchmark-sa` with the scope and secret name you created in step 1.
+
+When the cluster starts, the init script will run on every node, creating the file `/root/.config/gcloud/application_default_credentials.json`. The Spark Spanner connector and GCS connector will automatically pick up and use these credentials.
+
+#### 3. Required GCP IAM Roles
+
+The service account you use must have permissions to access both Spanner and the GCS bucket for results. Grant the following roles to your service account on your GCP project:
+
+*   **For Spanner Access**:
+    *   `roles/spanner.databaseUser`: Allows reading from and writing data to Spanner databases.
+    *   `roles/spanner.databaseAdmin`: Required by the setup tasks (`spannerUp`, `createBenchmarkSpannerTable`) to create and manage database schemas.
+*   **For GCS Access**:
+    *   `roles/storage.objectAdmin`: Allows writing benchmark results to your GCS bucket.
+
+## Benchmarking Workflow
+
+This section describes how to run benchmarks using sbt tasks.
+
+### sbt Tasks Overview
+
+*   `sbt "runBenchmark <benchmark_name>"`: Builds the connector, runs the specified benchmark on your Dataproc or Databricks cluster, and outputs the GCS path of the result file.
+*   `sbt "setBenchmarkBaseline <benchmark_name> <gcs_path>"`: Copies a specific benchmark run's result (identified by its full GCS path) to establish it as the baseline for future comparisons.
+*   `sbt "compareBenchmarkResults <benchmark_name> <gcs_path>"`: Downloads a specific benchmark run's result (identified by its full GCS path) and its corresponding baseline, then outputs a formatted comparison report.
+
+### Workflow
+
+1.  **Build the Connector**: From the root of the repository, build the connector and install it into your local Maven repository. This makes it available to the benchmark project.
+    ```bash
+    # Use the Spark version that matches your benchmark environment
+    mvn clean install -P3.3 -DskipTests
+    ```
+2.  **Run a Benchmark and Establish Baseline**:
+    *   Navigate to the `benchmark` directory.
+    *   Run your chosen benchmark (e.g., `dataproc-100k-records`):
+        ```bash
+        cd benchmark
+        sbt "runBenchmark dataproc-100k-records"
+        ```
+    *   The script will print the GCS path where the result JSON was uploaded (e.g., `gs://<your-results-bucket>/SparkSpannerWriteBenchmark/<timestamp>_<githash>.json`). Note down the full GCS path.
+    *   Use this path to set it as the baseline:
+        ```bash
+        sbt "setBenchmarkBaseline dataproc-100k-records <full_gcs_path_from_above>"
+        ```
+    This step effectively tags a known-good performance run as your reference point.
+
+3.  **Make Code Changes and Compare**:
+    *   Make any desired code changes to the Spark-Spanner connector.
+    *   Re-build the connector to ensure your changes are included:
+        ```bash
+        # From the project root
+        mvn clean install -P3.3 -DskipTests
+        ```
+    *   Run the same benchmark again to generate new results:
+        ```bash
+        # Still in the benchmark directory
+        sbt "runBenchmark dataproc-100k-records"
+        ```
+    *   Note down the GCS path for the new run from the output.
+    *   Compare the new results against your established baseline:
+        ```bash
+        sbt "compareBenchmarkResults dataproc-100k-records <full_gcs_path_for_new_run>"
+        ```
+    The task will output a formatted comparison report, showing performance deltas between your baseline and the new run.
+
+## Benchmark Results
+
+After a benchmark run is complete, the results are stored as a JSON file in the results GCS bucket.
+
+### Location
+
+You can find the results in the bucket specified by the `resultsBucket` property in your `environment.json` file.
+
+The directory structure and file naming convention is as follows:
+- **Bucket:** `gs://<results_bucket_name>/`
+- **Directory:** `/SparkSpannerWriteBenchmark/`
+- **File:** `/<run_id>.json`
+
+For example:
+`gs://my-spark-spanner-bench-results/SparkSpannerWriteBenchmark/2026-01-07T12-00-00Z_a1b2c3d4.json`
+
+Each JSON file contains detailed information about the run, including performance metrics, configuration parameters, and versions. For the detailed schema, see `RESULTS_SCHEMA.md`.
+
+## Troubleshooting
+
+### "Error: Catalog 'X' is not accessible in current workspace"
+
+This error indicates a mismatch between the Databricks workspace targeted by your CLI configuration and the one specified in `benchmarkDatabricks.json`, or a lack of proper permissions.
+
+**Possible Causes and Solutions:**
+
+1.  **Workspace Host Mismatch**:
+    *   **Diagnosis**: Your `databricks auth describe` command might show a different `Host` than the `databricksHost` value in your `benchmarkDatabricks.json`. The `sbt` task uses the host from `benchmarkDatabricks.json`.
+    *   **Solution**: Update the `databricksHost` in `benchmarkDatabricks.json` to match the host of the Databricks workspace where your Unity Catalog is correctly configured and accessible. Ensure all other Databricks-specific settings (`clusterId`, `ucVolumePath`) are valid for this workspace.
+
+2.  **Insufficient Permissions**: Even if the catalog is bound to the workspace, the user or service principal associated with your `databricksToken` might lack the necessary permissions.
+    *   **Diagnosis**:
+        *   Identify your user: `databricks auth describe`
+        *   List accessible catalogs: `databricks catalogs list` (check if your catalog is listed)
+        *   Check catalog permissions: `databricks grants get catalog your_catalog_name` (look for `USE_CATALOG`)
+        *   Check schema permissions: `databricks grants get schema your_catalog_name.your_schema_name` (look for `USE_SCHEMA`)
+        *   Check volume permissions: `databricks grants get volume your_catalog_name.your_schema_name.your_volume_name` (look for `WRITE_VOLUME` and `READ_VOLUME`)
+    *   **Solution**: A Databricks administrator needs to grant the required privileges to your user or a group you belong to. Specifically, ensure `USE_CATALOG`, `USE_SCHEMA`, and `WRITE_VOLUME`/`READ_VOLUME` (or `ALL_PRIVILEGES`) are granted.

--- a/benchmark/RESULTS_SCHEMA.md
+++ b/benchmark/RESULTS_SCHEMA.md
@@ -49,5 +49,5 @@ The results will be stored in the GCS bucket specified in the configuration.
 
 `gs://my-spark-spanner-bench-results/SparkSpannerWriteBenchmark/2026-01-07T12-00-00Z_a1b2c3d4.json`
 
-The `run_id` in the filename is a combination of a timestamp and a short, 8-character unique ID to ensure it's unique and sortable. The `runId` field in the JSON schema corresponds to this 8-character unique ID.
+The filename is a combination of a timestamp and a short, 8-character unique ID to ensure it's unique and sortable. The `runId` field in the JSON schema corresponds to this 8-character unique ID.
 

--- a/benchmark/RESULTS_SCHEMA.md
+++ b/benchmark/RESULTS_SCHEMA.md
@@ -1,0 +1,53 @@
+# Benchmark Results JSON Schema and File Convention
+
+This document defines the schema for the JSON files that store the results of benchmark runs, as well as the directory structure and naming convention for these files in the GCS bucket.
+
+## JSON Schema
+
+```json
+{
+  "runId": "string - A unique identifier for the benchmark run",
+  "runTimestamp": "string - ISO 8601 timestamp of the benchmark run",
+  "benchmarkName": "string - Name of the benchmark (e.g., SparkSpannerWriteBenchmark)",
+  "clusterSparkVersion": "string - The version of Spark used",
+  "connectorVersion": "string - The version of the Spanner-Spark connector",
+  "spannerConfig": {
+    "projectId": "string",
+    "instanceId": "string",
+    "databaseId": "string",
+    "table": "string"
+  },
+  "benchmarkParameters": {
+    "numRecords": "long",
+    "mutationsPerTransaction": "int",
+    "bytesPerTransaction": "long",
+    "numWriteThreads": "int",
+    "maxPendingTransactions": "int",
+    "assumeIdempotentRows": "boolean"
+  },
+  "performanceMetrics": {
+    "durationSeconds": "double - Total duration of the write operation in seconds",
+    "throughputMbPerSec": "double - Throughput in MB/s",
+    "totalSizeMb": "double - Total size of the generated data in MB",
+    "recordCount": "long - Number of records written"
+  },
+  "sparkConfig": {
+    "numPartitions": "int"
+  }
+}
+```
+
+## Directory Structure and File Naming Convention
+
+The results will be stored in the GCS bucket specified in the configuration.
+
+*   **Bucket:** `gs://<results_bucket_name>/`
+*   **Directory Structure:** `/<benchmark_name>/`
+*   **File Name:** `/<run_id>.json`
+
+### Example
+
+`gs://my-spark-spanner-bench-results/SparkSpannerWriteBenchmark/2026-01-07T12-00-00Z_a1b2c3d4.json`
+
+The `run_id` in the filename is a combination of a timestamp and a short, 8-character unique ID to ensure it's unique and sortable. The `runId` field in the JSON schema corresponds to this 8-character unique ID.
+

--- a/benchmark/benchmark_definitions.json
+++ b/benchmark/benchmark_definitions.json
@@ -10,14 +10,23 @@
       "mutationsPerTransaction": 1000
     },
     {
-      "name": "databricks-1mil-records",
-      "description": "A 1mil record write test on Databricks using a source table and default connector options.",
+      "name": "dataproc-5mil-records",
+      "description": "A  1mil record write test for validation on Dataproc.",
+      "environment": "dataproc",
+      "dataSource": "generated-data",
+      "numRecords": 5000000,
+      "numPartitions": 80,
+      "mutationsPerTransaction": 1000
+    },
+    {
+      "name": "databricks-5mil-records",
+      "description": "A 5mil record write test on Databricks using a source table and default connector options.",
       "environment": "databricks",
       "dataSource": "generated-data",
       "localNotebookPath" : "notebooks/SparkSpannerBenchmarkNotebook.scala",
       "localPrepareNotebookPath" : "notebooks/PrepareSource.scala",
-      "numPartitions": 16,
-      "numRecords": 1000000
+      "numPartitions": 80,
+      "numRecords": 5000000
     },
     {
       "name": "databricks-10mil-records",

--- a/benchmark/benchmark_definitions.json
+++ b/benchmark/benchmark_definitions.json
@@ -1,0 +1,55 @@
+{
+  "benchmarks": [
+    {
+      "name": "dataproc-100mil-records",
+      "description": "A  100mil record write test for validation on Dataproc.",
+      "environment": "dataproc",
+      "dataSource": "default-100mil-data",
+      "numRecords": 100000000,
+      "numPartitions": 800,
+      "mutationsPerTransaction": 1000
+    },
+    {
+      "name": "databricks-1mil-records",
+      "description": "A 1mil record write test on Databricks using a source table and default connector options.",
+      "environment": "databricks",
+      "dataSource": "generated-data",
+      "localNotebookPath" : "notebooks/SparkSpannerBenchmarkNotebook.scala",
+      "localPrepareNotebookPath" : "notebooks/PrepareSource.scala",
+      "numPartitions": 16,
+      "numRecords": 1000000
+    },
+    {
+      "name": "databricks-10mil-records",
+      "description": "A 10mil record write test on Databricks using a source table and default connector options.",
+      "environment": "databricks",
+      "dataSource": "generated-data",
+      "localNotebookPath" : "notebooks/SparkSpannerBenchmarkNotebook.scala",
+      "localPrepareNotebookPath" : "notebooks/PrepareSource.scala",
+      "numPartitions": 80,
+      "numRecords": 10000000
+    },
+
+    {
+      "name": "databricks-100mil-records",
+      "description": "A 100mil record write test on Databricks using a source table and default connector options.",
+      "environment": "databricks",
+      "dataSource": "generated-data",
+      "localNotebookPath" : "notebooks/SparkSpannerBenchmarkNotebook.scala",
+      "localPrepareNotebookPath" : "notebooks/PrepareSource.scala",
+      "numPartitions": 800,
+      "numRecords": 100000000
+    },
+    {
+      "name": "databricks-200mil-records",
+      "description": "A 200mil record write test on Databricks using a source table.",
+      "environment": "databricks",
+      "dataSource": "generated-data",
+      "localNotebookPath" : "notebooks/SparkSpannerBenchmarkNotebook.scala",
+      "localPrepareNotebookPath" : "notebooks/PrepareSource.scala",
+      "numPartitions": 1600,
+      "numRecords": 200000000,
+      "assumeIdempotentRows": true
+    }
+  ]
+}

--- a/benchmark/build.sbt
+++ b/benchmark/build.sbt
@@ -1,0 +1,59 @@
+import scala.sys.process._
+import BenchmarkingTasks._
+//
+// spanner-spark-tests
+//
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.12.15"
+
+val sparkSqlVersions = Map(
+  "3.1" -> "3.1.3",
+  "3.2" -> "3.2.4",
+  "3.3" -> "3.3.2"
+)
+val sparkVersion = sys.props.get("spark.version").getOrElse("3.3")
+
+val sparkSqlVersion = sparkSqlVersions.getOrElse(sparkVersion, {
+  sys.error(s"Unsupported spark.version: $sparkVersion. Supported versions are: ${sparkSqlVersions.keys.mkString(", ")}")
+})
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "spanner-spark-benchmark",
+    resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository",
+    dependencyOverrides ++= Seq(
+      "org.slf4j" % "slf4j-api" % "1.7.16",
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.15.2",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.2",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.15.2"
+    ),
+    libraryDependencies ++= Seq(
+      "com.google.cloud.spark.spanner" % s"spark-$sparkVersion-spanner" % "0.0.1-SNAPSHOT",
+      "org.apache.spark" %% "spark-sql" % sparkSqlVersion % "provided",
+      "com.typesafe.play" %% "play-json" % "2.9.2"
+    ),
+    Test / parallelExecution := false,
+    // sbt-assembly settings
+    assembly / assemblyShadeRules := Seq(
+      ShadeRule.rename("com.google.common.**" -> "com.google.cloud.spark.spanner.shaded.com.google.common.@1").inAll,
+      ShadeRule.rename("com.google.protobuf.**" -> "com.google.cloud.spark.spanner.shaded.com.google.protobuf.@1").inAll
+    ),
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", xs @ _*) if xs.exists(_.endsWith(".SF")) || xs.exists(_.endsWith(".DSA")) || xs.exists(_.endsWith(".RSA")) =>
+        MergeStrategy.discard
+      case PathList("META-INF", "services", "org.apache.spark.sql.sources.DataSourceRegister") =>
+        MergeStrategy.concat
+      case "reference.conf" =>
+        MergeStrategy.concat
+      case _ =>
+        MergeStrategy.first
+    },
+
+    Compile / mainClass := Some("com.google.cloud.spark.spanner.SparkSpannerWriteBenchmark"),
+    spannerUp := (BenchmarkingTasks.spannerUp.evaluated),
+    spannerDown := (BenchmarkingTasks.spannerDown.evaluated),
+  )
+  .settings(BenchmarkingTasks.customTaskSettings)
+
+
+

--- a/benchmark/data_sources.json
+++ b/benchmark/data_sources.json
@@ -1,0 +1,15 @@
+{
+  "dataSources": [
+    {
+      "name": "generated-data",
+      "description": "A table structure suitable for holding large, generated datasets.",
+      "ddlFile": "ddl/create_spanner_table.sql",
+      "generatorNotebook": "notebooks/PrepareSource.scala"
+    },
+    {
+      "name": "default-100k-data",
+      "description": "A table structure for the default 100k records generated in-memory by the benchmark.",
+      "ddlFile": "ddl/create_spanner_table.sql"
+    }
+  ]
+}

--- a/benchmark/ddl/create_spanner_table.sql
+++ b/benchmark/ddl/create_spanner_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE TransferTest (
+    id              STRING(36) NOT NULL,
+    json_payload    JSON,
+    short_label     STRING(100),
+    related_guid    STRING(36),
+    status_flag     STRING(1),
+    created_at      TIMESTAMP,
+    updated_at      TIMESTAMP
+) PRIMARY KEY (id);

--- a/benchmark/environment.json.template
+++ b/benchmark/environment.json.template
@@ -1,0 +1,30 @@
+{
+  "dataproc": {
+    "projectId": "your-gcp-project-id",
+    "instanceId": "your-spanner-instance-id",
+    "databaseId": "your-spanner-db-id",
+    "spannerRegion": "your-gcp-region",
+    "resultsBucket": "your-gcs-results-bucket",
+    "dataprocCluster": "your-dataproc-cluster-name",
+    "dataprocRegion": "your-dataproc-region",
+    "dataprocBucket": "your-dataproc-staging-bucket",
+    "dataSourceMappings": {
+      "generated-data": "ci_generated_data_v1",
+      "default-100k-data": "ci_default_100k"
+    }
+  },
+  "databricks": {
+    "projectId": "your-gcp-project-id",
+    "instanceId": "your-spanner-instance-id",
+    "databaseId": "your-spanner-db-id",
+    "resultsBucket": "your-gcs-results-bucket",
+    "databricksHost": "https://your-databricks-host",
+    "databricksToken": "dapi-your-token-here",
+    "clusterId": "your-cluster-id",
+    "ucVolumePath": "/Volumes/your/uc/path",
+    "dataSourceMappings": {
+      "generated-data": "dev_large_source",
+      "default-100k-data": "dev_default_100k"
+    }
+  }
+}

--- a/benchmark/notebooks/PrepareSource.scala
+++ b/benchmark/notebooks/PrepareSource.scala
@@ -1,0 +1,68 @@
+// Databricks notebook source
+// MAGIC %scala
+import org.apache.spark.sql.functions.{coalesce, col, current_timestamp, lit, udf}
+import java.util.UUID
+
+// This notebook generates source data for the Spark Spanner benchmark
+// and saves it as a Delta table.
+
+// 1. Declare widgets
+dbutils.widgets.text("sourceTable", "", "The name of the source Delta table to create")
+dbutils.widgets.text("numRecords", "100000", "Number of records to generate")
+
+// 2. Get parameters
+val sourceTable = dbutils.widgets.get("sourceTable")
+val numRecords = dbutils.widgets.get("numRecords").toLong
+
+if (sourceTable.isEmpty) {
+  dbutils.notebook.exit("ERROR: sourceTable widget cannot be empty.")
+}
+
+// 3. Define payload and schema
+private val payloadSample =
+  """
+{
+  "data": [
+    {"id": 1, "value": "a_long_string_to_make_the_file_bigger_01"},
+    {"id": 2, "value": "a_long_string_to_make_the_file_bigger_02"},
+    {"id": 3, "value": "a_long_string_to_make_the_file_bigger_03"},
+    {"id": 4, "value": "a_long_string_to_make_the_file_bigger_04"},
+    {"id": 5, "value": "a_long_string_to_make_the_file_bigger_05"},
+    {"id": 6, "value": "a_long_string_to_make_the_file_bigger_06"},
+    {"id": 7, "value": "a_long_string_to_make_the_file_bigger_07"},
+    {"id": 8, "value": "a_long_string_to_make_the_file_bigger_08"},
+    {"id": 9, "value": "a_long_string_to_make_the_file_bigger_09"},
+    {"id": 10, "value": "a_long_string_to_make_the_file_bigger_10"},
+    {"id": 11, "value": "a_long_string_to_make_the_file_bigger_11"},
+    {"id": 12, "value": "a_long_string_to_make_the_file_bigger_12"},
+    {"id": 13, "value": "a_long_string_to_make_the_file_bigger_13"},
+    {"id": 14, "value": "a_long_string_to_make_the_file_bigger_14"},
+    {"id": 15, "value": "a_long_string_to_make_the_file_bigger_15"},
+    {"id": 16, "value": "a_long_string_to_make_the_file_bigger_16"}
+  ]
+}
+""".stripMargin
+
+import spark.implicits._
+val generateUUID = udf(() => UUID.randomUUID().toString)
+
+println(s"Generating $numRecords records for source table '$sourceTable'...")
+
+val df = spark
+  .range(numRecords)
+  .select(
+    coalesce(generateUUID(), lit("0")).as("id"),
+    lit(payloadSample).as("json_payload"),
+    lit("short_label_constant").as("short_label"),
+    lit(UUID.nameUUIDFromBytes("related_guid_constant".getBytes).toString).as("related_guid"),
+    lit("A").as("status_flag"),
+    current_timestamp().as("created_at"),
+    current_timestamp().as("updated_at")
+  )
+
+// 4. Write to Delta table
+df.write.format("delta").mode("overwrite").saveAsTable(sourceTable)
+
+println(s"Successfully created source Delta table '$sourceTable' with $numRecords records.")
+
+dbutils.notebook.exit("SUCCESS")

--- a/benchmark/notebooks/SparkSpannerBenchmarkNotebook.scala
+++ b/benchmark/notebooks/SparkSpannerBenchmarkNotebook.scala
@@ -1,0 +1,175 @@
+%scala
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.functions.{coalesce, col, current_timestamp, lit, udf, row_number}
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.util.SizeEstimator
+import java.io.OutputStreamWriter
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.time.Duration
+import spark.implicits._
+
+// Declare widgets to define parameters for the notebook
+dbutils.widgets.text("projectId", "", "GCP Project ID")
+dbutils.widgets.text("instanceId", "", "Spanner Instance ID")
+dbutils.widgets.text("databaseId", "", "Spanner Database ID")
+dbutils.widgets.text("writeTable", "", "Spanner Table Name")
+dbutils.widgets.text("numRecords", "100000", "Number of records to write")
+dbutils.widgets.text("mutationsPerTransaction", "5000", "Mutations per transaction")
+dbutils.widgets.text("bytesPerTransaction", (3 * 1024 * 1024L).toString, "Bytes per transaction")
+dbutils.widgets.text("numWriteThreads", "4", "Number of write threads")
+dbutils.widgets.text("maxPendingTransactions", "5", "Maximum pending transactions")
+dbutils.widgets.text("assumeIdempotentRows", "true", "Assume idempotent rows")
+dbutils.widgets.text("resultsBucket", "", "GCS Bucket for results")
+dbutils.widgets.text("buildSparkVersion", "3.3", "Spark version used for the connector")
+dbutils.widgets.text("numPartitions", "40", "Number of partitions for the DataFrame")
+dbutils.widgets.text("sourceTable", "", "The name of the source Delta table to read from")
+
+println("Running Spark Spanner Connector Benchmark...")
+
+val projectId = dbutils.widgets.get("projectId")
+val instanceId = dbutils.widgets.get("instanceId")
+val databaseId = dbutils.widgets.get("databaseId")
+val writeTable = dbutils.widgets.get("writeTable")
+val sourceTable = dbutils.widgets.get("sourceTable")
+val numRecords = dbutils.widgets.get("numRecords").toLong
+
+// Use get for widgets, then fallback to default if empty
+def getOrDefault(name: String, default: String): String = {
+  val v = dbutils.widgets.get(name)
+  if (v == null || v.isEmpty) default else v
+}
+
+val mutationsPerTransaction = getOrDefault("mutationsPerTransaction", "5000").toInt
+val bytesPerTransaction = getOrDefault("bytesPerTransaction", (3 * 1024 * 1024L).toString).toLong
+val numWriteThreads = getOrDefault("numWriteThreads", "4").toInt
+val maxPendingTransactions = getOrDefault("maxPendingTransactions", "5").toInt
+val assumeIdempotentRows = getOrDefault("assumeIdempotentRows", "true").toBoolean
+val resultsBucket = dbutils.widgets.get("resultsBucket")
+val buildSparkVersion = dbutils.widgets.get("buildSparkVersion")
+val generateUUID = udf(() => UUID.randomUUID().toString)
+
+val numPartitions = getOrDefault("numPartitions", "40").toInt
+
+if (numRecords > Int.MaxValue) {
+  dbutils.notebook.exit(s"ERROR: numRecords ($numRecords) exceeds the maximum value for an Integer (${Int.MaxValue}) and cannot be used with the 'limit' function.")
+}
+
+if (sourceTable.isEmpty) {
+  dbutils.notebook.exit("ERROR: sourceTable widget cannot be empty.")
+}
+
+
+println(s"Reading from source table '$sourceTable'...")
+val dfSource = spark.read.table(sourceTable)
+
+val sourceTableCount = dfSource.count() // Get the total count of the source table
+
+println(s"Source table '$sourceTable' has $sourceTableCount records.")
+
+if (numRecords > sourceTableCount) {
+  dbutils.notebook.exit(s"ERROR: Requested number of records ($numRecords) is greater than available records in source table ($sourceTableCount). Aborting benchmark.")
+}
+
+println(s"Selecting $numRecords records for the benchmark...")
+val dfWrite = dfSource.limit(numRecords.toInt).cache()
+
+val averageRowSizeBytes = SizeEstimator.estimate(dfWrite.first())
+val sizeInBytes = averageRowSizeBytes * numRecords
+val sizeMb = sizeInBytes / (1024 * 1024)
+println(s"Estimated job size: $sizeMb MB")
+println(f"Average row size: $averageRowSizeBytes bytes")
+println(s"Number of partitions: $numPartitions")
+
+val dfPartitioned = dfWrite.repartition(numPartitions).sortWithinPartitions(col("id"))
+println(s"Beginning write to table '$writeTable' with mutationsPerTransaction: $mutationsPerTransaction")
+val startTime = System.nanoTime()
+val provider = s"com.google.cloud.spark.spanner.Spark${buildSparkVersion.replace(".", "")}SpannerTableProvider"
+dfPartitioned
+  .write
+  .format(provider)
+  .option("mutationsPerTransaction", mutationsPerTransaction)
+  .option("bytesPerTransaction", bytesPerTransaction.toString)
+  .option("projectId", projectId)
+  .option("instanceId", instanceId)
+  .option("databaseId", databaseId)
+  .option("numWriteThreads", numWriteThreads.toString)
+  .option("assumeIdempotentRows", assumeIdempotentRows.toString)
+  .option("maxPendingTransactions", maxPendingTransactions.toString)
+  .option("table", writeTable)
+  .mode(SaveMode.Append)
+  .save()
+val endTime = System.nanoTime()
+val durationSeconds = Duration.ofNanos(endTime - startTime).toMillis
+val throughput = sizeMb / durationSeconds
+
+println("Ending write")
+println(s"Write operation took: $durationSeconds seconds")
+println(f"Throughput: $throughput%.2f MB/s")
+
+val runId = UUID.randomUUID().toString.take(8)
+val runTimestamp = java.time.format.DateTimeFormatter.ISO_INSTANT.format(java.time.Instant.now())
+val sparkVersion = spark.version
+val connectorVersion = "0.0.1-SNAPSHOT"
+
+val resultJson =
+  s"""{
+    "runId": "$runId",
+    "runTimestamp": "$runTimestamp",
+    "benchmarkName": "SparkSpannerWriteBenchmark",
+    "clusterSparkVersion": "$sparkVersion",
+    "connectorVersion": "$connectorVersion",
+    "spannerConfig": {
+      "projectId": "$projectId",
+      "instanceId": "$instanceId",
+      "databaseId": "$databaseId",
+      "table": "$writeTable"
+    },
+    "benchmarkParameters": {
+      "numRecords": $numRecords,
+      "mutationsPerTransaction": $mutationsPerTransaction,
+      "bytesPerTransaction": $bytesPerTransaction,
+      "numWriteThreads": $numWriteThreads,
+      "maxPendingTransactions": $maxPendingTransactions,
+      "assumeIdempotentRows": $assumeIdempotentRows
+    },
+    "performanceMetrics": {
+      "durationSeconds": $durationSeconds,
+      "throughputMbPerSec": $throughput,
+      "totalSizeMb": $sizeMb,
+      "recordCount": $numRecords
+    },
+    "sparkConfig": {
+      "numPartitions": $numPartitions
+    }
+  }"""
+
+// Expects path for Application Default Credentials (ADC) file
+val gcpADCKeyFilePath = "/root/.config/gcloud/application_default_credentials.json"
+println(s"Configuring GCS connector with Application Default Credentials from: $gcpADCKeyFilePath")
+
+// Set Hadoop configuration for GCS connector using the ADC file
+spark.sparkContext.hadoopConfiguration.set("google.cloud.auth.service.account.enable", "true")
+spark.sparkContext.hadoopConfiguration.set("google.cloud.auth.service.account.json.keyfile", gcpADCKeyFilePath)
+
+val resultsPath = s"gs://$resultsBucket/SparkSpannerWriteBenchmarkNotebook/${runTimestamp}_$runId.json"
+println(s"Writing results to $resultsPath")
+
+val resultsURI = new URI(resultsPath)
+val fs = FileSystem.get(resultsURI, spark.sparkContext.hadoopConfiguration)
+val outputPath = new Path(resultsPath)
+val os = fs.create(outputPath, true)
+val writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)
+try {
+  writer.write(resultJson)
+} finally {
+  writer.close()
+  os.close()
+}
+
+println("Finished writing results.")
+
+dfWrite.unpersist()
+dbutils.notebook.exit("SUCCESS")

--- a/benchmark/notebooks/SparkSpannerBenchmarkNotebook.scala
+++ b/benchmark/notebooks/SparkSpannerBenchmarkNotebook.scala
@@ -172,4 +172,4 @@ try {
 println("Finished writing results.")
 
 dfWrite.unpersist()
-dbutils.notebook.exit("SUCCESS")
+dbutils.notebook.exit(resultsURI.toString())

--- a/benchmark/notebooks/SparkSpannerBenchmarkNotebook.scala
+++ b/benchmark/notebooks/SparkSpannerBenchmarkNotebook.scala
@@ -78,7 +78,7 @@ val dfWrite = dfSource.limit(numRecords.toInt).cache()
 
 val averageRowSizeBytes = SizeEstimator.estimate(dfWrite.first())
 val sizeInBytes = averageRowSizeBytes * numRecords
-val sizeMb = sizeInBytes / (1024 * 1024)
+val sizeMb = sizeInBytes / (1024.0 * 1024.0)
 println(s"Estimated job size: $sizeMb MB")
 println(f"Average row size: $averageRowSizeBytes bytes")
 println(s"Number of partitions: $numPartitions")
@@ -102,7 +102,7 @@ dfPartitioned
   .mode(SaveMode.Append)
   .save()
 val endTime = System.nanoTime()
-val durationSeconds = Duration.ofNanos(endTime - startTime).toMillis
+val durationSeconds = Duration.ofNanos(endTime - startTime).toMillis / 1000.0
 val throughput = sizeMb / durationSeconds
 
 println("Ending write")

--- a/benchmark/project/BenchmarkingTasks.scala
+++ b/benchmark/project/BenchmarkingTasks.scala
@@ -1,0 +1,638 @@
+import sbt._
+import Keys._
+import scala.sys.process._
+import sbtassembly.AssemblyKeys.assembly
+import play.api.libs.json._
+
+object BenchmarkingTasks {
+
+  lazy val buildBenchmarkJar = taskKey[File]("Builds the spanner test suite JAR.")
+  lazy val runDatabricksNotebook = inputKey[Unit]("Runs a notebook on Databricks.")
+  lazy val refreshDatabricksToken = inputKey[Unit]("Refreshes the Databricks token.")
+  lazy val spannerUp = inputKey[Unit]("Ensures spanner instance, database and table exist for benchmark.")
+  lazy val spannerDown = inputKey[Unit]("Removes the spanner instance, and its databases, referenced in the benchmark config.")
+  lazy val createBenchmarkSpannerTable = inputKey[Unit]("Creates the Spanner table required for a specific benchmark scenario.")
+  lazy val runBenchmark = inputKey[Unit]("Runs a specified benchmark scenario in a given environment.")
+  lazy val setBenchmarkBaseline = inputKey[Unit]("Sets a specific benchmark run as the baseline.")
+  lazy val compareBenchmarkResults = inputKey[Unit]("Compares a specific benchmark run against the baseline.")
+
+  private def loadBenchmarkConfig(file: File): JsValue = {
+    Json.parse(IO.read(file))
+  }
+
+  // Common helper to get benchmark and environment info
+  private def getBenchmarkContext(benchmarkName: String, baseDir: File): (JsObject, JsObject, String) = {
+    val envFile = baseDir / "environment.json"
+    if (!envFile.exists()) sys.error(s"Environment file not found at ${envFile.getAbsolutePath}.")
+    val environmentConfig = loadBenchmarkConfig(envFile)
+
+    val defsFile = baseDir / "benchmark_definitions.json"
+    if (!defsFile.exists()) sys.error(s"Benchmark definitions file not found at ${defsFile.getAbsolutePath}.")
+    val benchmarkDefs = (Json.parse(IO.read(defsFile)) \ "benchmarks").as[JsArray]
+
+    val benchmarkDef = benchmarkDefs.value.find(b => (b \ "name").as[String] == benchmarkName).getOrElse {
+      sys.error(s"Benchmark definition for '$benchmarkName' not found in benchmark_definitions.json.")
+    }.as[JsObject]
+
+    val environmentType = (benchmarkDef \ "environment").asOpt[String].getOrElse {
+      sys.error(s"Benchmark '$benchmarkName' does not have an 'environment' field in its definition.")
+    }
+
+    val specificEnvConfig = (environmentConfig \ environmentType).asOpt[JsObject].getOrElse {
+      sys.error(s"Configuration for environment '$environmentType' not found in environment.json.")
+    }
+
+    (benchmarkDef, specificEnvConfig, environmentType)
+  }
+
+  // Helper to derive the write table name
+  private def deriveWriteTableName(benchmarkName: String): String = {
+    val sanitizedName = benchmarkName.replaceAll("[^a-zA-Z0-9_]", "_")
+    s"benchmark_${sanitizedName}_dest"
+  }
+
+
+  private def runDatabricksNotebookHelper(config: JsValue, baseDirectory: File): Unit = {
+    val databricksHost = (config \ "databricksHost").as[String]
+    val databricksToken = (config \ "databricksToken").as[String]
+    val clusterId = (config \ "clusterId").as[String]
+    val baseDatabricksWorkspacePath = (config \ "notebookPath").asOpt[String].getOrElse("/Shared") // Base path in Databricks Workspace
+    val localNotebookFilePath = (config \ "localNotebookFilePath").as[String] // Path to the local notebook file
+    val notebookBasename = new java.io.File(localNotebookFilePath).getName
+    val notebookPath = s"${baseDatabricksWorkspacePath.stripSuffix("/")}/$notebookBasename"
+
+    // 1. Import notebook
+    val language = localNotebookFilePath.substring(localNotebookFilePath.lastIndexOf('.') + 1).toUpperCase match {
+      case "PY" => "PYTHON"
+      case "SQL" => "SQL"
+      case "R" => "R"
+      case "SCALA" => "SCALA"
+      case other => sys.error(s"Unsupported notebook language extension: .$other")
+    }
+
+    println(s"Importing notebook $localNotebookFilePath to $notebookPath on Databricks...")
+    val importCommand = Seq(
+      "databricks", "workspace", "import", notebookPath,
+      "--file", (baseDirectory / localNotebookFilePath).toString,
+      "--language", language,
+      "--format", "SOURCE",
+      "--overwrite"
+    )
+    println(s"Executing command: ${importCommand.mkString(" ")}")
+    val importExitCode = Process(importCommand, None, "DATABRICKS_HOST" -> databricksHost, "DATABRICKS_TOKEN" -> databricksToken).!
+    if (importExitCode != 0) {
+      sys.error(s"Failed to import notebook to Databricks.")
+    }
+    println("Notebook imported successfully.")
+
+    // 2. Prepare parameters
+    val databricksKeys = Set("databricksHost", "databricksToken", "clusterId", "notebookPath", "localNotebookFilePath", "localPrepareNotebookPath", "ucVolumePath")
+    val allParams = config.as[JsObject].value.filterKeys(k => !databricksKeys.contains(k))
+    val baseParameters = JsObject(
+      allParams.map { case (key, value) =>
+        key -> (value match {
+          case s: JsString => s
+          case other => Json.toJson(other.toString)
+        })
+      }.toSeq
+    )
+
+    // 3. Run notebook
+    val jobJson = Json.obj(
+      "run_name" -> "Spark Spanner Benchmark",
+      "tasks" -> Json.arr(
+        Json.obj(
+          "task_key" -> "benchmark_task",
+          "notebook_task" -> Json.obj(
+            "notebook_path" -> notebookPath,
+            "source" -> "WORKSPACE",
+            "base_parameters" -> baseParameters
+          ),
+          "existing_cluster_id" -> clusterId
+        )
+      )
+    )
+    val jobJsonString = Json.stringify(jobJson)
+
+      println(s"Submitting job for notebook $notebookPath on cluster $clusterId...")
+      val runCommand = Seq(
+        "databricks", "jobs", "submit", "--json", jobJsonString
+      )
+      println(s"Executing command: databricks jobs submit --json '...' and capturing output.")
+      
+      // Capture the output of the command
+      val output = Process(runCommand, None, "DATABRICKS_HOST" -> databricksHost, "DATABRICKS_TOKEN" -> databricksToken).!!.trim
+      
+      // Parse the JSON output
+      val resultJson = Json.parse(output)
+      val runId = (resultJson \ "run_id").as[Long]
+      val runPageUrl = (resultJson \ "run_page_url").as[String]
+      
+      println(s"Job submitted successfully. Run ID: $runId")
+      println(s"Monitor progress at: $runPageUrl")
+    }
+  
+    lazy val customTaskSettings: Seq[Setting[_]] = Seq(
+      runBenchmark := {
+        import scala.util.Try
+
+        val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+        if (args.isEmpty) {
+          sys.error("Usage: sbt \"runBenchmark <benchmarkName>\"")
+        }
+        val benchmarkName = args(0)
+        val baseDir = baseDirectory.value
+        val (benchmarkDef, specificEnvConfig, environmentType) = getBenchmarkContext(benchmarkName, baseDir)
+
+        // Load data sources to resolve source table
+        val dataSourcesFile = baseDir / "data_sources.json"
+        if (!dataSourcesFile.exists()) {
+          sys.error(s"Data sources file not found at ${dataSourcesFile.getAbsolutePath}.")
+        }
+        val dataSources = (Json.parse(IO.read(dataSourcesFile)) \ "dataSources").as[JsArray]
+
+        val logicalDataSourceName = (benchmarkDef \ "dataSource").asOpt[String]
+        var resolvedSourceTable: Option[String] = None
+
+        logicalDataSourceName.foreach {
+          dsName =>
+          val dataSourceMappings = (specificEnvConfig \ "dataSourceMappings").asOpt[JsObject].getOrElse(Json.obj())
+          resolvedSourceTable = (dataSourceMappings \ dsName).asOpt[String]
+          if (resolvedSourceTable.isEmpty) {
+              sys.error(s"Physical table mapping for logical data source '$dsName' not found in environment.json for environment '$environmentType'.")
+          }
+        }
+
+        // --- Generate writeTableName ---
+        val physicalWriteTableName = deriveWriteTableName(benchmarkName)
+
+
+        // Merge configurations
+        var tempConfig = benchmarkDef.deepMerge(specificEnvConfig)
+        tempConfig = tempConfig - "writeTableName" + ("writeTable" -> Json.toJson(physicalWriteTableName))
+        resolvedSourceTable.foreach(s => tempConfig = tempConfig + ("sourceTable" -> Json.toJson(s)))
+        tempConfig = tempConfig + ("buildSparkVersion" -> Json.toJson(sys.props.get("spark.version").getOrElse("3.3")))
+        
+        val finalMergedConfig = tempConfig
+        val configJsonString = Json.stringify(finalMergedConfig)
+        println(s"Running benchmark with merged configuration: ${configJsonString}")
+
+        // Execute the Spark job
+        environmentType match {
+          case "dataproc" =>
+            val appJar = (assembly in ThisProject).value
+            val mc = (Compile / mainClass).value.getOrElse(throw new RuntimeException("mainClass not found"))
+
+            val cluster = (finalMergedConfig \ "dataprocCluster").as[String]
+            val region = (finalMergedConfig \ "dataprocRegion").as[String]
+            val bucketName = (finalMergedConfig \ "dataprocBucket").as[String]
+            val projectId = (finalMergedConfig \ "projectId").as[String]
+
+            val runId = java.time.format.DateTimeFormatter.ISO_INSTANT.format(java.time.Instant.now()) + "_" + java.util.UUID.randomUUID().toString.take(8)
+            val gcsPath = s"gs://$bucketName/connector-test-$runId"
+            
+            val dest = s"$gcsPath/${appJar.getName}"
+            println(s"Uploading ${appJar.getAbsolutePath} to $dest")
+            s"gcloud storage cp ${appJar.getAbsolutePath} $dest".!
+
+            val command = Seq(
+              "gcloud", "dataproc", "jobs", "submit", "spark",
+              s"--cluster=$cluster",
+              s"--region=$region",
+              s"--project=$projectId",
+              s"--class=$mc",
+              s"--jars=$dest",
+              "--"
+            ) ++ Seq(configJsonString)
+
+            println(s"Submitting Dataproc job: ${command.mkString(" ")}")
+            
+            val jobOutput = new StringBuilder
+            val errorOutput = new StringBuilder
+            val exitCode = command.!(ProcessLogger(
+              line => {
+                println(line)
+                jobOutput.append(line).append("\n")
+              },
+              line => {
+                System.err.println(line)
+                errorOutput.append(line).append("\n")
+              }
+            ))
+
+            if (exitCode != 0) {
+              sys.error(s"Dataproc job submission failed with exit code $exitCode.\nStderr:\n${errorOutput.toString}")
+            }
+
+            val resultPathPattern = """Writing results to (gs://[^\s]+)""" .r
+            resultPathPattern.findFirstMatchIn(jobOutput.toString).map(_.group(1)) match {
+              case Some(path) =>
+                println("\n" + ("-" * 50))
+                println("Benchmark Run Complete")
+                println(s"Result file created at: $path")
+                println(("-" * 50) + "\n")
+              case None =>
+                println("\nWarning: Could not automatically find the results file path in the Dataproc job output.")
+            }
+
+          case "databricks" =>
+            val notebookPath = (benchmarkDef \ "localNotebookPath").as[String]
+            val configWithLocalPath = finalMergedConfig + ("localNotebookFilePath" -> Json.toJson(notebookPath))
+            runDatabricksNotebookHelper(configWithLocalPath, baseDir)
+
+          case _ =>
+            sys.error(s"Unsupported environment type: '$environmentType'.")
+        }
+      },
+      
+      setBenchmarkBaseline := {
+        val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+        if (args.length < 2) {
+          sys.error("Usage: sbt \"setBenchmarkBaseline <benchmarkName> <gcsPath>\"")
+        }
+        val benchmarkName = args.head
+        val sourceGcsPath = args(1)
+        val baseDir = baseDirectory.value
+        
+        val (_, specificEnvConfig, _) = getBenchmarkContext(benchmarkName, baseDir)
+        val resultsBucket = (specificEnvConfig \ "resultsBucket").as[String]
+        
+        val baselineGcsPath = s"gs://${resultsBucket}/SparkSpannerWriteBenchmark/${benchmarkName}-baseline.json"
+        
+        println(s"--- Setting Baseline for ${benchmarkName} ---")
+        println(s"Copying ${sourceGcsPath} to ${baselineGcsPath}")
+        
+        val command = Seq("gsutil", "cp", sourceGcsPath, baselineGcsPath)
+        if (command.! != 0) {
+          sys.error("Failed to set baseline.")
+        }
+        println("Baseline set successfully.")
+      },
+
+      compareBenchmarkResults := {
+        val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+        if (args.length < 2) {
+          sys.error("Usage: sbt \"compare <benchmarkName> <gcsPath>\"")
+        }
+        val benchmarkName = args.head
+        val currentGcsPath = args(1)
+        val baseDir = baseDirectory.value
+
+        val (_, specificEnvConfig, _) = getBenchmarkContext(benchmarkName, baseDir)
+        val resultsBucket = (specificEnvConfig \ "resultsBucket").as[String]
+        
+        val baselineGcsPath = s"gs://${resultsBucket}/SparkSpannerWriteBenchmark/${benchmarkName}-baseline.json"
+        
+        val tempDir = IO.createTemporaryDirectory
+        
+        println(s"--- Comparing ${benchmarkName} (run ${currentGcsPath}) against baseline ---")
+        println(s"Downloading files to temporary directory: ${tempDir.getAbsolutePath}")
+        
+        val baselineFile = tempDir / "baseline.json"
+        val currentFile = tempDir / "current.json"
+
+        val gsutilCpBaseline = Seq("gsutil", "cp", baselineGcsPath, baselineFile.getAbsolutePath)
+        val gsutilCpCurrent = Seq("gsutil", "cp", currentGcsPath, currentFile.getAbsolutePath)
+        
+        if (gsutilCpBaseline.! != 0) {
+          IO.delete(tempDir)
+          sys.error(s"Failed to download baseline file from GCS: ${baselineGcsPath}")
+        }
+        if (gsutilCpCurrent.! != 0) {
+          IO.delete(tempDir)
+          sys.error(s"Failed to download current result file from GCS: ${currentGcsPath}")
+        }
+        
+        println("--- Generating Comparison Report ---")
+
+        val baselineJson = Json.parse(IO.read(baselineFile))
+        val currentJson = Json.parse(IO.read(currentFile))
+
+        val baselineMetrics = (baselineJson \ "performanceMetrics").as[JsObject]
+        val currentMetrics = (currentJson \ "performanceMetrics").as[JsObject]
+
+        case class Metric(name: String, key: String)
+        val metricsToCompare = Seq(
+          Metric("Duration (s)", "durationSeconds"),
+          Metric("Throughput (MB/s)", "throughputMbPerSec"),
+          Metric("Records Written", "recordCount")
+        )
+
+        def formatChange(baseline: Double, current: Double): String = {
+          if (baseline == 0) "N/A"
+          else {
+            val change = ((current - baseline) / baseline) * 100
+            val emoji = if (change > 0) "📈" else "📉"
+            f"$change%+.2f%% $emoji"
+          }
+        }
+
+        println("\n## 🚀 Spark Spanner Connector Benchmark Report\n")
+        println("| Metric              | Baseline   | Current PR | Change      |")
+        println("|---------------------|------------|------------|-------------|")
+
+        metricsToCompare.foreach {
+          metric =>
+          val baselineValue = (baselineMetrics \ metric.key).asOpt[Double].getOrElse(0.0)
+          val currentValue = (currentMetrics \ metric.key).asOpt[Double].getOrElse(0.0)
+          val changeStr = formatChange(baselineValue, currentValue)
+          
+          val formattedBaseline = f"$baselineValue%10.2f"
+          val formattedCurrent = f"$currentValue%10.2f"
+          
+          println(f"| ${metric.name}%-19s | ${formattedBaseline} | ${formattedCurrent} | ${changeStr}%-11s |")
+        }
+        
+        println("")
+        
+        IO.delete(tempDir)
+      },
+
+      createBenchmarkSpannerTable := {
+        val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+        if (args.isEmpty) {
+          sys.error("Usage: sbt \"createBenchmarkSpannerTable <benchmarkName>\"")
+        }
+        val benchmarkName = args(0)
+        val baseDir = baseDirectory.value
+
+        val (benchmarkDef, specificEnvConfig, _) = getBenchmarkContext(benchmarkName, baseDir)
+        
+        val dataSourcesFile = baseDir / "data_sources.json"
+        if (!dataSourcesFile.exists()) sys.error(s"Data sources file not found at ${dataSourcesFile.getAbsolutePath}.")
+        val dataSources = (Json.parse(IO.read(dataSourcesFile)) \ "dataSources").as[JsArray]
+
+        val projectId = (specificEnvConfig \ "projectId").as[String]
+        val instanceId = (specificEnvConfig \ "instanceId").as[String]
+        val databaseId = (specificEnvConfig \ "databaseId").as[String]
+        val writeTableName = deriveWriteTableName(benchmarkName)
+
+        val logicalDataSourceName = (benchmarkDef \ "dataSource").asOpt[String].getOrElse {
+          sys.error(s"Benchmark '$benchmarkName' does not specify a 'dataSource' to infer DDL from.")
+        }
+        val dataSourceDef = dataSources.value.find(ds => (ds \ "name").as[String] == logicalDataSourceName).getOrElse {
+          sys.error(s"Logical data source '$logicalDataSourceName' not found in data_sources.json.")
+        }
+        val ddlFile = (dataSourceDef \ "ddlFile").as[String]
+        val ddlContent = IO.read(baseDir / ddlFile).replace("TransferTest", writeTableName)
+
+
+        println(s"Checking for Spanner table '$writeTableName' in database '$databaseId'...")
+        val checkTableCommand = Seq(
+          "gcloud", "spanner", "databases", "ddl", "describe", databaseId,
+          s"--instance=$instanceId",
+          s"--project=$projectId"
+        )
+        val ddlOutput = checkTableCommand.!!
+        if (ddlOutput.contains(s"CREATE TABLE $writeTableName")) {
+          println(s"Table '$writeTableName' already exists in database '$databaseId'.")
+        } else {
+          println(s"Table '$writeTableName' not found, creating it...")
+          val createTableCommand = Seq(
+            "gcloud", "spanner", "databases", "ddl", "update", databaseId,
+            s"--instance=$instanceId",
+            s"--project=$projectId",
+            s"--ddl=$ddlContent"
+          )
+
+          println(s"Executing DDL to create table '$writeTableName' in database '$databaseId':")
+          println(ddlContent)
+
+          if (createTableCommand.! != 0) {
+            sys.error(s"Failed to create table '$writeTableName'.")
+          } else {
+            println(s"Successfully created table '$writeTableName'.")
+          }
+        }
+      },
+
+      spannerDown := {
+        val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+        if (args.isEmpty) {
+          sys.error("Usage: sbt \"spannerDown <benchmarkName>\"")
+        }
+        val benchmarkName = args(0)
+        val baseDir = baseDirectory.value
+        val (_, specificEnvConfig, _) = getBenchmarkContext(benchmarkName, baseDir)
+
+        val instanceId = (specificEnvConfig \ "instanceId").as[String]
+        val projectId = (specificEnvConfig \ "projectId").as[String]
+
+        println(s"Attempting to tear down Spanner instance '$instanceId' in project '$projectId'...")
+
+        // 1. Check if instance exists
+        val checkInstanceCommand = Seq("gcloud", "spanner", "instances", "describe", instanceId, s"--project=$projectId")
+        if (checkInstanceCommand.! != 0) {
+          println(s"Spanner instance '$instanceId' does not exist or you don't have permissions. Nothing to delete.")
+        } else {
+          // 2. List and delete databases within the instance
+          println(s"Listing databases in instance '$instanceId'...")
+          val listDatabasesCommand = Seq(
+            "gcloud", "spanner", "databases", "list",
+            s"--instance=$instanceId",
+            s"--project=$projectId",
+            "--format=json"
+          )
+          val databasesJson = Process(listDatabasesCommand).!!.trim
+          val databases = Json.parse(databasesJson).as[JsArray]
+
+          if (databases.value.isEmpty) {
+            println(s"No databases found in instance '$instanceId'.")
+          } else {
+            databases.value.foreach { db =>
+              val databaseId = (db \ "name").as[String].split("/").last
+              println(s"Deleting database '$databaseId' from instance '$instanceId'...")
+              val deleteDbCommand = Seq(
+                "gcloud", "spanner", "databases", "delete", databaseId,
+                s"--instance=$instanceId",
+                s"--project=$projectId",
+                "--quiet"
+              )
+              println(s"Running command: ${deleteDbCommand.mkString(" ")}")
+              if (deleteDbCommand.! != 0) {
+                println(s"Warning: Failed to delete database '$databaseId'. It might be already gone or permissions issue.")
+              } else {
+                println(s"Successfully initiated deletion of database '$databaseId'.")
+              }
+            }
+          }
+
+          // 3. Delete the Spanner instance
+          println(s"Deleting Spanner instance '$instanceId'...")
+          val deleteInstanceCommand = Seq(
+            "gcloud", "spanner", "instances", "delete", instanceId,
+            s"--project=$projectId",
+            "--quiet"
+          )
+          println(s"Running command: ${deleteInstanceCommand.mkString(" ")}")
+          if (deleteInstanceCommand.! != 0) {
+            sys.error(s"Failed to delete Spanner instance '$instanceId'.")
+          } else {
+            println(s"Successfully initiated deletion of Spanner instance '$instanceId'.")
+          }
+        }
+      },
+      
+      spannerUp := {
+        val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+        if (args.isEmpty) {
+          sys.error("Usage: sbt \"spannerUp <benchmarkName>\"")
+        }
+        val benchmarkName = args.head
+        val baseDir = baseDirectory.value
+        val (benchmarkDef, specificEnvConfig, _) = getBenchmarkContext(benchmarkName, baseDir)
+
+        val instanceId = (specificEnvConfig \ "instanceId").as[String]
+        val projectId = (specificEnvConfig \ "projectId").as[String]
+        val databaseId = (specificEnvConfig \ "databaseId").as[String]
+
+        // 1. Ensure Spanner instance exists.
+        println(s"Checking for Spanner instance '$instanceId'...")
+        val checkInstanceCommand = Seq("gcloud", "spanner", "instances", "describe", instanceId, s"--project=$projectId")
+        if (checkInstanceCommand.! != 0) {
+          println(s"Spanner instance '$instanceId' not found, creating it...")
+          val spannerRegion = (specificEnvConfig \ "spannerRegion").asOpt[String].getOrElse("us-central1")
+          val createInstanceCommand = Seq(
+            "gcloud", "spanner", "instances", "create", instanceId,
+            s"--project=$projectId",
+            s"--config=regional-$spannerRegion",
+            s"--description=$instanceId",
+            s"--autoscaling-min-processing-units=2000",
+            s"--autoscaling-max-processing-units=20000",
+            s"--autoscaling-high-priority-cpu-target=65",
+            s"--autoscaling-storage-target=90",
+            s"--edition=ENTERPRISE"
+          )
+          println(s"Running command: ${createInstanceCommand.mkString(" ")}")
+          if (createInstanceCommand.! != 0) {
+            sys.error(s"Failed to create Spanner instance '$instanceId'.")
+          }
+          println(s"Successfully initiated creation of Spanner instance '$instanceId'.")
+        } else {
+          println(s"Spanner instance '$instanceId' already exists.")
+        }
+
+        // 2. Ensure Spanner database exists.
+        println(s"Checking for Spanner database '$databaseId' in instance '$instanceId'...")
+        val checkDbCommand = Seq("gcloud", "spanner", "databases", "describe", databaseId, s"--instance=$instanceId", s"--project=$projectId")
+        if (checkDbCommand.! != 0) {
+          println(s"Spanner database '$databaseId' not found, creating it...")
+          val createDbCommand = Seq(
+            "gcloud", "spanner", "databases", "create", databaseId,
+            s"--instance=$instanceId",
+            s"--project=$projectId"
+          )
+          println(s"Running command: ${createDbCommand.mkString(" ")}")
+          if (createDbCommand.! != 0) {
+            sys.error(s"Failed to create Spanner database '$databaseId' in instance '$instanceId'.")
+          }
+          println(s"Successfully initiated creation of Spanner database '$databaseId'.")
+        } else {
+          println(s"Spanner database '$databaseId' already exists.")
+        }
+
+        // 3. Ensure Spanner table exists.
+        val tableName = deriveWriteTableName(benchmarkName)
+        println(s"Checking for Spanner table '$tableName' in database '$databaseId'...")
+        val checkTableCommand = Seq(
+          "gcloud", "spanner", "databases", "ddl", "describe", databaseId,
+          s"--instance=$instanceId",
+          s"--project=$projectId"
+        )
+        val ddlOutput = checkTableCommand.!!
+        if (ddlOutput.contains(s"CREATE TABLE $tableName")) {
+          println(s"Table '$tableName' already exists in database '$databaseId'.")
+        } else {
+          println(s"Table '$tableName' not found, creating it...")
+          val dataSourcesFile = baseDir / "data_sources.json"
+          if (!dataSourcesFile.exists()) sys.error(s"Data sources file not found at ${dataSourcesFile.getAbsolutePath}.")
+          val dataSources = (Json.parse(IO.read(dataSourcesFile)) \ "dataSources").as[JsArray]
+
+          val logicalDataSourceName = (benchmarkDef \ "dataSource").asOpt[String].getOrElse {
+            sys.error(s"Benchmark '$benchmarkName' does not specify a 'dataSource' to infer DDL from.")
+          }
+          val dataSourceDef = dataSources.value.find(ds => (ds \ "name").as[String] == logicalDataSourceName).getOrElse {
+            sys.error(s"Logical data source '$logicalDataSourceName' not found in data_sources.json.")
+          }
+          val ddlFile = (dataSourceDef \ "ddlFile").as[String]
+          val ddlContent = IO.read(baseDir / ddlFile).replace("TransferTest", tableName)
+          
+          val createTableCommand = Seq(
+            "gcloud", "spanner", "databases", "ddl", "update", databaseId,
+            s"--instance=$instanceId",
+            s"--project=$projectId",
+            s"--ddl=$ddlContent"
+          )
+
+          println(s"Executing DDL to create table '$tableName' in database '$databaseId':")
+          println(ddlContent)
+
+          if (createTableCommand.! != 0) {
+            sys.error(s"Failed to create table '$tableName'.")
+          } else {
+            println(s"Successfully created table '$tableName'.")
+          }
+        }
+      },
+
+      runDatabricksNotebook := {
+      val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
+      if (args.isEmpty) {
+        sys.error("Usage: sbt \"runDatabricksNotebook <path-to-notebook>\"")
+      }
+      val notebookPath = args.head
+      val baseDir = baseDirectory.value
+
+      val envFile = baseDir / "environment.json"
+      if (!envFile.exists()) sys.error(s"Environment file not found at ${envFile.getAbsolutePath}.")
+      val environmentConfig = loadBenchmarkConfig(envFile)
+
+      val databricksConfig = (environmentConfig \ "databricks").asOpt[JsObject].getOrElse {
+        sys.error("Configuration for environment 'databricks' not found in environment.json.")
+      }
+
+      val configWithNotebook = databricksConfig + ("localNotebookFilePath" -> Json.toJson(notebookPath))
+
+      runDatabricksNotebookHelper(configWithNotebook, baseDir)
+    },
+
+      refreshDatabricksToken := {
+      val baseDir = baseDirectory.value
+      val envFile = baseDir / "environment.json"
+      if (!envFile.exists()) {
+        sys.error(s"Environment file not found at ${envFile.getAbsolutePath}. Please create it from the template.")
+      }
+
+      println("Requesting new Databricks token via Databricks CLI...")
+      val lifetimeSeconds = 3600 // 1 hour
+      val createTokenCommand = Seq(
+        "databricks", "tokens", "create",
+        "--comment", "Temporary token for Spark Spanner benchmark",
+        "--lifetime-seconds", lifetimeSeconds.toString
+      )
+
+      val output = try {
+        Process(createTokenCommand).!!.trim
+      } catch {
+        case ex: Exception => sys.error("Failed to create Databricks token. Make sure the Databricks CLI is installed and configured with a valid token that has permission to create new tokens.")
+      }
+
+      val tokenJson = Json.parse(output)
+      val newToken = (tokenJson \ "token_value").as[String]
+
+      val environmentConfig = loadBenchmarkConfig(envFile).as[JsObject]
+      
+      val databricksConfig = (environmentConfig \ "databricks").asOpt[JsObject].getOrElse {
+        sys.error("'databricks' section not found in environment.json.")
+      }
+      
+      val updatedDatabricksConfig = databricksConfig + ("databricksToken" -> Json.toJson(newToken))
+      val updatedEnvironmentConfig = environmentConfig + ("databricks" -> updatedDatabricksConfig)
+      
+      IO.write(envFile, Json.prettyPrint(updatedEnvironmentConfig))
+      println(s"Successfully updated databricksToken in ${envFile.getAbsolutePath}.")
+    },
+
+      buildBenchmarkJar := (assembly in ThisProject).value,
+  )
+}

--- a/benchmark/project/BenchmarkingTasks.scala
+++ b/benchmark/project/BenchmarkingTasks.scala
@@ -174,7 +174,7 @@ object BenchmarkingTasks {
         tempConfig = tempConfig + ("buildSparkVersion" -> Json.toJson(sys.props.get("spark.version").getOrElse("3.3")))
         
         val finalMergedConfig = tempConfig
-        val configJsonString = Json.stringify(finalMergedConfig)
+        val configJsonString = Json.stringify(finalMergedConfig - "databricksToken") // Do not log Databricks token
         println(s"Running benchmark with merged configuration: ${configJsonString}")
 
         // Execute the Spark job

--- a/benchmark/project/build.properties
+++ b/benchmark/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/benchmark/project/build.sbt
+++ b/benchmark/project/build.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.2"

--- a/benchmark/project/plugins.sbt
+++ b/benchmark/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/benchmark/setup_gcp_credentials.sh
+++ b/benchmark/setup_gcp_credentials.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# This script configures Google Application Default Credentials on a Databricks cluster.
+# It reads a GCP service account key from an environment variable and writes it to the
+# default location expected by Google Cloud client libraries.
+
+set -e
+
+# The environment variable that holds the content of the GCP credentials JSON.
+# This must be configured in the cluster's settings.
+GCP_CREDENTIALS_CONTENT="$GCP_CREDENTIALS"
+
+if [ -z "$GCP_CREDENTIALS_CONTENT" ]; then
+  echo "Error: The GCP_CREDENTIALS environment variable is not set." >&2
+  echo "Please configure this in the Spark Cluster Environment Variables:" >&2
+  echo "GCP_CREDENTIALS={{secrets/gcp-credentials/spanner-benchmark-sa}}" >&2
+  exit 1
+fi
+
+# Path for the Application Default Credentials (ADC) file.
+# The script will create this for the user that Spark runs as.
+ADC_DIR="/root/.config/gcloud"
+ADC_FILE="$ADC_DIR/application_default_credentials.json"
+
+echo "Creating directory for ADC file: $ADC_DIR"
+mkdir -p "$ADC_DIR"
+
+echo "Writing credentials to $ADC_FILE"
+# Write the content of the environment variable to the file.
+cat > "$ADC_FILE" <<EOF
+$GCP_CREDENTIALS_CONTENT
+EOF
+
+echo "Successfully configured Google Application Default Credentials."

--- a/benchmark/src/main/scala/com/google/cloud/spark/spanner/SparkSpannerWriteBenchmark.scala
+++ b/benchmark/src/main/scala/com/google/cloud/spark/spanner/SparkSpannerWriteBenchmark.scala
@@ -83,7 +83,7 @@ object SparkSpannerWriteBenchmark {
     // Dynamically calculate the average row size
     val averageRowSizeBytes = SizeEstimator.estimate(dfWrite.first())
     val sizeInBytes = averageRowSizeBytes * numRecords
-    val sizeMb = sizeInBytes / (1024 * 1024)
+    val sizeMb = sizeInBytes / (1024.0 * 1024.0)
     println(s"Estimated job size: $sizeMb MB")
     println(f"Average row size: $averageRowSizeBytes bytes")
     println(s"Number of partitions: $numPartitions")

--- a/benchmark/src/main/scala/com/google/cloud/spark/spanner/SparkSpannerWriteBenchmark.scala
+++ b/benchmark/src/main/scala/com/google/cloud/spark/spanner/SparkSpannerWriteBenchmark.scala
@@ -1,0 +1,172 @@
+package com.google.cloud.spark.spanner
+
+import org.apache.spark.util.SizeEstimator
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.functions.{coalesce, col, current_timestamp, lit, udf}
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import play.api.libs.json.{JsValue, Json}
+
+import java.io.OutputStreamWriter
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+object SparkSpannerWriteBenchmark {
+  private val payloadSample =
+    """
+      |{
+      |  "data": [
+      |    {"id": 1, "value": "a_long_string_to_make_the_file_bigger_01"},
+      |    {"id": 2, "value": "a_long_string_to_make_the_file_bigger_02"},
+      |    {"id": 3, "value": "a_long_string_to_make_the_file_bigger_03"},
+      |    {"id": 4, "value": "a_long_string_to_make_the_file_bigger_04"},
+      |    {"id": 5, "value": "a_long_string_to_make_the_file_bigger_05"},
+      |    {"id": 6, "value": "a_long_string_to_make_the_file_bigger_06"},
+      |    {"id": 7, "value": "a_long_string_to_make_the_file_bigger_07"},
+      |    {"id": 8, "value": "a_long_string_to_make_the_file_bigger_08"},
+      |    {"id": 9, "value": "a_long_string_to_make_the_file_bigger_09"},
+      |    {"id": 10, "value": "a_long_string_to_make_the_file_bigger_10"},
+      |    {"id": 11, "value": "a_long_string_to_make_the_file_bigger_11"},
+      |    {"id": 12, "value": "a_long_string_to_make_the_file_bigger_12"},
+      |    {"id": 13, "value": "a_long_string_to_make_the_file_bigger_13"},
+      |    {"id": 14, "value": "a_long_string_to_make_the_file_bigger_14"},
+      |    {"id": 15, "value": "a_long_string_to_make_the_file_bigger_15"},
+      |    {"id": 16, "value": "a_long_string_to_make_the_file_bigger_16"}
+      |  ]
+      |}
+      |""".stripMargin
+
+  def main(args: Array[String]): Unit = {
+    if (args.length < 1) {
+      println("Usage: SparkSpannerBenchmark <benchmark-config-json>")
+      sys.exit(1)
+    }
+    val configStr = args(0)
+    val config: JsValue = Json.parse(configStr)
+
+    val numRecords = (config \ "numRecords").as[Long]
+    val writeTable = (config \ "writeTable").as[String]
+    val databaseId = (config \ "databaseId").as[String]
+    val instanceId = (config \ "instanceId").as[String]
+    val projectId = (config \ "projectId").as[String]
+    val resultsBucket = (config \ "resultsBucket").as[String]
+    val buildSparkVersion = (config \ "buildSparkVersion").as[String]
+
+    val mutationsPerTransaction = (config \ "mutationsPerTransaction").asOpt[Int].getOrElse(5000)
+    val bytesPerTransaction = (config \ "bytesPerTransaction").asOpt[Long].getOrElse(3 * 1024 * 1024L)
+    val numWriteThreads = (config \ "numWriteThreads").asOpt[Int].getOrElse(4)
+    val maxPendingTransactions = (config \ "maxPendingTransactions").asOpt[Int].getOrElse(5)
+    val assumeIdempotentRows = (config \ "assumeIdempotentRows").asOpt[Boolean].getOrElse(true)
+    
+    val defaultPartitions = 5 * 4 * 2 // workerCount * coreCount * 2
+    val numPartitions = (config \ "numPartitions").asOpt[Int].getOrElse(defaultPartitions)
+
+    val spark = SparkSession.builder().appName("SparkSpannerWriteBenchmark").getOrCreate()
+
+    val generateUUID = udf(() => UUID.randomUUID().toString)
+
+    println("Test: Writing data with new schema...")
+
+    val dfWrite = spark
+      .range(numRecords)
+      .select(
+        coalesce(generateUUID(), lit("0")).as("id"),
+        lit(payloadSample).as("json_payload"),
+        lit("short_label_constant").as("short_label"),
+        lit(UUID.nameUUIDFromBytes("related_guid_constant".getBytes).toString).as("related_guid"),
+        lit("A").as("status_flag"),
+        current_timestamp().as("created_at"),
+        current_timestamp().as("updated_at")
+      )
+      .cache() // Cache the DataFrame for size estimation and the write operation
+
+    // Dynamically calculate the average row size
+    val averageRowSizeBytes = SizeEstimator.estimate(dfWrite.first())
+    val sizeInBytes = averageRowSizeBytes * numRecords
+    val sizeMb = sizeInBytes / (1024 * 1024)
+    println(s"Estimated job size: $sizeMb MB")
+    println(f"Average row size: $averageRowSizeBytes bytes")
+    println(s"Number of partitions: $numPartitions")
+
+    val dfPartitioned = dfWrite.repartition(numPartitions).sortWithinPartitions(col("id"))
+
+    println(s"Beginning write to table '$writeTable' with mutationsPerTransaction: $mutationsPerTransaction")
+    val startTime = System.nanoTime()
+    val provider = s"com.google.cloud.spark.spanner.Spark${buildSparkVersion.replace(".", "")}SpannerTableProvider"
+    dfPartitioned
+      .write
+      .format(provider)
+      .option("mutationsPerTransaction", mutationsPerTransaction)
+      .option("bytesPerTransaction", bytesPerTransaction.toString)
+      .option("projectId", projectId)
+      .option("instanceId", instanceId)
+      .option("databaseId", databaseId)
+      .option("numWriteThreads", numWriteThreads.toString)
+      .option("assumeIdempotentRows", assumeIdempotentRows.toString)
+      .option("maxPendingTransactions", maxPendingTransactions.toString)
+      .option("table", writeTable)
+      .mode(SaveMode.Append)
+      .save()
+    dfWrite.unpersist() // Release the cached DataFrame
+    val endTime = System.nanoTime()
+    val durationSeconds = (endTime - startTime) / 1e9
+    val throughput = sizeMb / durationSeconds
+
+    println("Ending write")
+    println(s"Write operation took: $durationSeconds seconds")
+    println(f"Throughput: $throughput%.2f MB/s")
+
+    val runId = UUID.randomUUID().toString.take(8)
+    val runTimestamp = java.time.format.DateTimeFormatter.ISO_INSTANT.format(java.time.Instant.now())
+    val sparkVersion = spark.version
+    val connectorVersion = "0.1.0"
+
+    val resultJson = Json.obj(
+      "runId" -> runId,
+      "runTimestamp" -> runTimestamp,
+      "benchmarkName" -> "SparkSpannerWriteBenchmark",
+      "clusterSparkVersion" -> sparkVersion,
+      "connectorVersion" -> connectorVersion,
+      "spannerConfig" -> Json.obj(
+        "projectId" -> projectId,
+        "instanceId" -> instanceId,
+        "databaseId" -> databaseId,
+        "table" -> writeTable
+      ),
+      "benchmarkParameters" -> Json.obj(
+        "numRecords" -> numRecords,
+        "mutationsPerTransaction" -> mutationsPerTransaction,
+        "bytesPerTransaction" -> bytesPerTransaction,
+        "numWriteThreads" -> numWriteThreads,
+        "maxPendingTransactions" -> maxPendingTransactions,
+        "assumeIdempotentRows" -> assumeIdempotentRows
+      ),
+      "performanceMetrics" -> Json.obj(
+        "durationSeconds" -> durationSeconds,
+        "throughputMbPerSec" -> throughput,
+        "totalSizeMb" -> sizeMb,
+        "recordCount" -> numRecords
+      ),
+      "sparkConfig" -> Json.obj(
+        "numPartitions" -> numPartitions
+      )
+    )
+
+    val resultsPath = s"gs://$resultsBucket/SparkSpannerWriteBenchmark/${runTimestamp}_$runId.json"
+    println(s"Writing results to $resultsPath")
+
+    val resultsURI = new URI(resultsPath)
+    val fs = FileSystem.get(resultsURI, spark.sparkContext.hadoopConfiguration)
+    val outputPath = new Path(resultsPath)
+    val os = fs.create(outputPath, true) // true to overwrite
+    val writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)
+    try {
+      writer.write(Json.prettyPrint(resultJson))
+    } finally {
+      writer.close()
+      os.close()
+    }
+
+    println("Finished writing results.")
+  }
+}

--- a/benchmark/src/main/scala/com/google/cloud/spark/spanner/SparkSpannerWriteBenchmark.scala
+++ b/benchmark/src/main/scala/com/google/cloud/spark/spanner/SparkSpannerWriteBenchmark.scala
@@ -119,7 +119,7 @@ object SparkSpannerWriteBenchmark {
     val runId = UUID.randomUUID().toString.take(8)
     val runTimestamp = java.time.format.DateTimeFormatter.ISO_INSTANT.format(java.time.Instant.now())
     val sparkVersion = spark.version
-    val connectorVersion = "0.1.0"
+    val connectorVersion = "0.0.1-SNAPSHOT"
 
     val resultJson = Json.obj(
       "runId" -> runId,

--- a/examples/databricks/README.md
+++ b/examples/databricks/README.md
@@ -68,7 +68,7 @@ gcloud spanner databases create spark_spanner_db_example \
 # Create the table using the local DDL file
 gcloud spanner databases ddl update spark_spanner_db_example \
   --instance=$SPANNER_INSTANCE_ID \
-  --ddl-file=./create_source_table.sql
+  --ddl-file=./create_test_table.sql
 ```
 
 ### 3. Create and Configure a Service Account

--- a/examples/databricks/README.md
+++ b/examples/databricks/README.md
@@ -68,7 +68,7 @@ gcloud spanner databases create spark_spanner_db_example \
 # Create the table using the local DDL file
 gcloud spanner databases ddl update spark_spanner_db_example \
   --instance=$SPANNER_INSTANCE_ID \
-  --ddl-file=./create_test_table.sql
+  --ddl-file=./create_source_table.sql
 ```
 
 ### 3. Create and Configure a Service Account


### PR DESCRIPTION
This PR adds a a couple benchmark jobs and tooling to run them and manage results.

A benchmark is a bundle of -- a Spark job, runtime parameters, and environment.

The PR adds two benchmark jobs -- one to generate data and write it to Spanner, and another to read data from a Delta table and write to Spanner.

Benchmarks can be run on GCP Dataproc or Databricks.

Each benchmark job writes a JSON file with test configuration and results to a GCS bucket. The project includes tooling for saving these results as baseline and comparing another result to baseline.

See `benchmark/README.md` for details.