### PR TITLE
Implement overwrite save mode  (#26)

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInformationSchema.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerInformationSchema.java
@@ -70,6 +70,10 @@ public interface SpannerInformationSchema {
     return ddl.toString();
   }
 
+  default Statement truncateTableDml(String tableName) {
+    return Statement.of("DELETE FROM " + quoteIdentifier(tableName) + " WHERE true");
+  }
+
   default String dropTableDdl(String tableName) {
     return "DROP TABLE " + quoteIdentifier(tableName);
   }

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerTable.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerTable.java
@@ -54,7 +54,8 @@ public class SpannerTable implements Table, SupportsRead, SupportsWrite {
   private final SpannerTableSchema dbSchema;
   private final @Nullable StructType dfSchema;
   private static final ImmutableSet<TableCapability> tableCapabilities =
-      ImmutableSet.of(TableCapability.BATCH_READ, TableCapability.BATCH_WRITE);
+      ImmutableSet.of(
+          TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.TRUNCATE);
   private final CaseInsensitiveStringMap properties;
 
   private static final Logger log = LoggerFactory.getLogger(SpannerTable.class);

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
@@ -53,7 +53,7 @@ public class SpannerWriteBuilder implements WriteBuilder, SupportsTruncate {
 
   @Override
   public WriteBuilder truncate() {
-    CaseInsensitiveStringMap opts = new CaseInsensitiveStringMap(this.info.options());
+    CaseInsensitiveStringMap opts = this.info.options();
     String overwriteMode = opts.getOrDefault("overwriteMode", "truncate");
 
     if (overwriteMode.equalsIgnoreCase("recreate")) {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
@@ -14,22 +14,126 @@
 
 package com.google.cloud.spark.spanner;
 
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Statement;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.SupportsTruncate;
 import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class SpannerWriteBuilder implements WriteBuilder {
+public class SpannerWriteBuilder implements WriteBuilder, SupportsTruncate {
+
+  private static final Logger log = LoggerFactory.getLogger(SpannerWriteBuilder.class);
   private final LogicalWriteInfo info;
   private final CaseInsensitiveStringMap properties;
+  private final StructType schema;
 
   public SpannerWriteBuilder(LogicalWriteInfo info, CaseInsensitiveStringMap properties) {
     this.info = info;
     this.properties = properties;
+    this.schema = info.schema();
   }
 
   @Override
   public BatchWrite buildForBatch() {
     return new SpannerBatchWrite(info, properties);
+  }
+
+  @Override
+  public WriteBuilder truncate() {
+    CaseInsensitiveStringMap opts = new CaseInsensitiveStringMap(this.info.options());
+    String overwriteMode = opts.getOrDefault("overwriteMode", "truncate");
+
+    if (overwriteMode.equalsIgnoreCase("recreate")) {
+      recreateTable(this.properties);
+    } else if (overwriteMode.equalsIgnoreCase("truncate")) {
+      truncateTable(this.properties);
+    } else {
+      throw new SpannerConnectorException(
+          SpannerErrorCode.INVALID_ARGUMENT,
+          "Unsupported overwriteMode '"
+              + overwriteMode
+              + "'. Supported modes are 'recreate' and 'truncate'.");
+    }
+
+    return this;
+  }
+
+  private void recreateTable(CaseInsensitiveStringMap opts) {
+    String projectId = SpannerUtils.getRequiredOption(opts, "projectId");
+    String instanceId = SpannerUtils.getRequiredOption(opts, "instanceId");
+    String databaseId = SpannerUtils.getRequiredOption(opts, "databaseId");
+    String tableName = SpannerUtils.getRequiredOption(opts, "table");
+
+    try (Spanner spanner = SpannerUtils.buildSpannerOptions(opts).getService()) {
+      DatabaseAdminClient dbAdminClient = spanner.getDatabaseAdminClient();
+      Dialect dialect = dbAdminClient.getDatabase(instanceId, databaseId).getDialect();
+      SpannerInformationSchema schemaInfo = SpannerInformationSchema.create(dialect);
+
+      String dropDdl = schemaInfo.dropTableDdl(tableName);
+      dbAdminClient
+          .updateDatabaseDdl(instanceId, databaseId, Collections.singletonList(dropDdl), null)
+          .get();
+
+      // Create the table.
+      Identifier ident = Identifier.of(new String[0], tableName);
+      String createDdl = schemaInfo.createTableDdl(ident, this.schema);
+      dbAdminClient
+          .updateDatabaseDdl(instanceId, databaseId, Collections.singletonList(createDdl), null)
+          .get();
+
+    } catch (InterruptedException | ExecutionException e) {
+      throw new SpannerConnectorException(
+          SpannerErrorCode.DDL_EXCEPTION, "Error recreating table " + tableName, e);
+    }
+  }
+
+  private void truncateTable(CaseInsensitiveStringMap opts) {
+    String projectId = SpannerUtils.getRequiredOption(opts, "projectId");
+    String instanceId = SpannerUtils.getRequiredOption(opts, "instanceId");
+    String databaseId = SpannerUtils.getRequiredOption(opts, "databaseId");
+    String tableName = SpannerUtils.getRequiredOption(opts, "table");
+
+    try (Spanner spanner = SpannerUtils.buildSpannerOptions(opts).getService()) {
+      DatabaseClient dbClient =
+          spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
+      Dialect dialect = dbClient.getDialect();
+
+      SpannerInformationSchema informationSchema = SpannerInformationSchema.create(dialect);
+
+      truncateTable(dbClient, tableName, informationSchema);
+    } catch (SpannerException e) {
+      throw new SpannerConnectorException(
+          SpannerErrorCode.DDL_EXCEPTION, "Error truncating table " + tableName, e);
+    }
+  }
+
+  private long truncateTable(
+      DatabaseClient dbClient, String tableName, SpannerInformationSchema informationSchema) {
+
+    Statement statement = informationSchema.truncateTableDml(tableName);
+
+    try {
+      // Execute partitioned update. This is a blocking call.
+      long deletedRowCount = dbClient.executePartitionedUpdate(statement);
+      log.info("Successfully deleted " + deletedRowCount + " rows.");
+      return deletedRowCount;
+
+    } catch (SpannerException e) {
+      log.error("Failed to execute Partitioned DML on table: " + tableName, e);
+      throw e;
+    }
   }
 }

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
@@ -116,7 +116,7 @@ public class SpannerWriteBuilder implements WriteBuilder, SupportsTruncate {
       truncateTable(dbClient, tableName, informationSchema);
     } catch (SpannerException e) {
       throw new SpannerConnectorException(
-          SpannerErrorCode.DDL_EXCEPTION, "Error truncating table " + tableName, e);
+          SpannerErrorCode.SPANNER_FAILED_TO_EXECUTE_QUERY, "Error truncating table " + tableName, e);
     }
   }
 

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerWriteBuilder.java
@@ -116,7 +116,9 @@ public class SpannerWriteBuilder implements WriteBuilder, SupportsTruncate {
       truncateTable(dbClient, tableName, informationSchema);
     } catch (SpannerException e) {
       throw new SpannerConnectorException(
-          SpannerErrorCode.SPANNER_FAILED_TO_EXECUTE_QUERY, "Error truncating table " + tableName, e);
+          SpannerErrorCode.SPANNER_FAILED_TO_EXECUTE_QUERY,
+          "Error truncating table " + tableName,
+          e);
     }
   }
 

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/integration/SpannerCatalogIntegrationTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/integration/SpannerCatalogIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.cloud.spark.spanner.SpannerCatalog;
 import com.google.cloud.spark.spanner.SpannerConnectorException;
 import com.google.cloud.spark.spanner.SpannerTable;
+import com.google.cloud.spark.spanner.TestData;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -31,8 +32,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.types.DataTypes;
@@ -52,6 +54,11 @@ public class SpannerCatalogIntegrationTest extends SparkCatalogSpannerIntegratio
 
   private SpannerCatalog catalog;
   private final boolean usePostgresSql;
+
+  @Override
+  protected boolean getUsePostgreSql() {
+    return usePostgresSql;
+  }
 
   @Parameters
   public static Collection<Object[]> usePostgresSqlValues() {
@@ -124,7 +131,7 @@ public class SpannerCatalogIntegrationTest extends SparkCatalogSpannerIntegratio
   }
 
   @Test
-  public void testCreateTable() throws NoSuchTableException, TableAlreadyExistsException {
+  public void testCreateTable() throws NoSuchTableException {
     String tableName = "new_test_table";
     Identifier ident = Identifier.of(new String[0], tableName);
     StructType createSchema =
@@ -191,5 +198,79 @@ public class SpannerCatalogIntegrationTest extends SparkCatalogSpannerIntegratio
     Dataset<Row> df = spark.sql("SELECT * FROM spanner.simpleTable");
     assertThat(df.count()).isGreaterThan(0);
     assertThat(df.columns()).asList().containsExactly("A", "B", "C");
+  }
+
+  @Test
+  public void testOverwriteRecreateMode() {
+    testOverwriteImpl("recreate");
+  }
+
+  @Test
+  public void testOverwriteTruncateMode() {
+    testOverwriteImpl("truncate");
+  }
+
+  private void testOverwriteImpl(String mode) {
+    final StructType SIMPLE_SCHEMA =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField(
+                  "long_col", DataTypes.LongType, false, SpannerCatalog.PRIMARY_KEY_METADATA),
+              DataTypes.createStructField("string_col", DataTypes.StringType, true),
+            });
+
+    String tableName = TestData.WRITE_TABLE_NAME + "_" + mode;
+    String qualifiedTableName = "spanner." + tableName;
+    spark.sql("DROP TABLE IF EXISTS " + qualifiedTableName);
+
+    // 1. Define schema with primary key metadata (needed for table recreation)
+
+    Map<String, String> props = connectionProperties(usePostgresSql);
+    props.put("table", tableName);
+    props.put("overwriteMode", mode);
+
+    // 2. Write initial data (creates the table via ErrorIfExists)
+    List<Row> initialRows =
+        Arrays.asList(RowFactory.create(1L, "initial-one"), RowFactory.create(2L, "initial-two"));
+    Dataset<Row> initialDf = spark.createDataFrame(initialRows, SIMPLE_SCHEMA);
+    initialDf
+        .write()
+        .format("cloud-spanner")
+        .options(props)
+        .mode(SaveMode.ErrorIfExists)
+        .saveAsTable(qualifiedTableName);
+
+    // 3. Verify initial data
+    Dataset<Row> dfAfterInitialWrite =
+        spark.read().format("cloud-spanner").options(props).table(qualifiedTableName);
+    assertEquals(2, dfAfterInitialWrite.count());
+
+    // 4. Overwrite with recreate mode
+    List<Row> newRows =
+        Arrays.asList(
+            RowFactory.create(3L, "new-three"),
+            RowFactory.create(4L, "new-four"),
+            RowFactory.create(5L, "new-five"));
+    Dataset<Row> newDf = spark.createDataFrame(newRows, SIMPLE_SCHEMA);
+
+    newDf
+        .write()
+        .format("cloud-spanner")
+        .options(props)
+        .mode(SaveMode.Overwrite)
+        .save(qualifiedTableName);
+
+    // 5. Verify only new data exists
+    Dataset<Row> finalDf =
+        spark.read().format("cloud-spanner").options(props).load(qualifiedTableName);
+    assertEquals(3, finalDf.count());
+
+    Map<Long, Row> finalRows =
+        finalDf.collectAsList().stream()
+            .collect(java.util.stream.Collectors.toMap(r -> r.getLong(0), r -> r));
+
+    assertThat(finalRows.get(3L).getString(1)).isEqualTo("new-three");
+    assertThat(finalRows.get(4L).getString(1)).isEqualTo("new-four");
+    assertThat(finalRows.get(5L).getString(1)).isEqualTo("new-five");
   }
 }

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/integration/SpannerCatalogIntegrationTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/integration/SpannerCatalogIntegrationTest.java
@@ -52,6 +52,13 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class SpannerCatalogIntegrationTest extends SparkCatalogSpannerIntegrationTestBase {
 
+  public static final StructType SIMPLE_SCHEMA =
+      new StructType(
+          new StructField[] {
+            DataTypes.createStructField(
+                "long_col", DataTypes.LongType, false, SpannerCatalog.PRIMARY_KEY_METADATA),
+            DataTypes.createStructField("string_col", DataTypes.StringType, true),
+          });
   private SpannerCatalog catalog;
   private final boolean usePostgresSql;
 
@@ -210,15 +217,56 @@ public class SpannerCatalogIntegrationTest extends SparkCatalogSpannerIntegratio
     testOverwriteImpl("truncate");
   }
 
-  private void testOverwriteImpl(String mode) {
-    final StructType SIMPLE_SCHEMA =
-        new StructType(
-            new StructField[] {
-              DataTypes.createStructField(
-                  "long_col", DataTypes.LongType, false, SpannerCatalog.PRIMARY_KEY_METADATA),
-              DataTypes.createStructField("string_col", DataTypes.StringType, true),
-            });
+  @Test
+  public void testOverwriteCreatesTableRecreateMode() {
+    testOverwriteCreatesTableImpl("recreate");
+  }
 
+  @Test
+  public void testOverwriteCreatesTableTruncateMode() {
+    testOverwriteCreatesTableImpl("truncate");
+  }
+
+  private void testOverwriteCreatesTableImpl(String mode) {
+
+    String tableName = TestData.WRITE_TABLE_NAME + "_overwrite_creates_" + mode;
+    String qualifiedTableName = "spanner." + tableName;
+    spark.sql("DROP TABLE IF EXISTS " + qualifiedTableName);
+
+    Map<String, String> props = connectionProperties(usePostgresSql);
+    props.put("table", tableName);
+    props.put("overwriteMode", mode);
+
+    // Verify the table does not exist before the overwrite call
+    Identifier ident = Identifier.of(new String[0], tableName);
+    assertFalse(catalog.tableExists(ident));
+
+    // Write data with Overwrite mode to a non-existent table
+    List<Row> rows = Arrays.asList(RowFactory.create(1L, "one"), RowFactory.create(2L, "two"));
+    Dataset<Row> df = spark.createDataFrame(rows, SIMPLE_SCHEMA);
+
+    df.write()
+        .format("cloud-spanner")
+        .options(props)
+        .mode(SaveMode.Overwrite)
+        .saveAsTable(qualifiedTableName);
+
+    // Verify the table was created and contains the expected data
+    assertTrue(catalog.tableExists(ident));
+
+    Dataset<Row> resultDf =
+        spark.read().format("cloud-spanner").options(props).load(qualifiedTableName);
+    assertEquals(2, resultDf.count());
+
+    Map<Long, Row> resultRows =
+        resultDf.collectAsList().stream()
+            .collect(java.util.stream.Collectors.toMap(r -> r.getLong(0), r -> r));
+
+    assertThat(resultRows.get(1L).getString(1)).isEqualTo("one");
+    assertThat(resultRows.get(2L).getString(1)).isEqualTo("two");
+  }
+
+  private void testOverwriteImpl(String mode) {
     String tableName = TestData.WRITE_TABLE_NAME + "_" + mode;
     String qualifiedTableName = "spanner." + tableName;
     spark.sql("DROP TABLE IF EXISTS " + qualifiedTableName);


### PR DESCRIPTION
This PR adds support Overwrite save mode. It also adds `overwriteMode` option with two possible values:
- `truncate` -- All rows in the table will be deleted. incoming dataframe must matching existing schema.
- `recreate` -- table will be dropped and recreated based on the schema of the incoming dataframe.

---------