### PR TITLE
Use case-insensitive map to look up value of mutationType option

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerDataWriter.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SpannerDataWriter.java
@@ -113,7 +113,8 @@ public class SpannerDataWriter implements DataWriter<InternalRow> {
         Integer.parseInt(
             caseInsensitiveStringMap.getOrDefault(
                 "maxPendingTransactions", MAX_PENDING_TRANSACTIONS_DEFAULT_STR));
-    this.mutationType = parseMutationType(properties.getOrDefault("mutationType", null));
+    this.mutationType =
+        parseMutationType(caseInsensitiveStringMap.getOrDefault("mutationType", null));
 
     this.batchClient = batchClient;
     this.executor = executor;

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerDataWriterTestBase.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerDataWriterTestBase.java
@@ -26,6 +26,7 @@ import com.google.api.gax.rpc.ServerStream;
 import com.google.cloud.spanner.BatchClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
@@ -55,6 +56,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -422,6 +424,40 @@ public abstract class SpannerDataWriterTestBase {
         assertThat(e.getCause().getMessage()).contains("Spanner BatchWrite failed with status");
       }
     }
+  }
+
+  @Test
+  public void testMutationTypeCamelCaseIsHonored() throws IOException {
+    properties.put("mutationType", "insert");
+    try (SpannerDataWriter writer = createWriter(properties)) {
+      when(mockDatabaseClient.write(any())).thenReturn(null);
+      writer.write(CreateInternalRow(1L));
+      writer.commit();
+    }
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<java.util.List<Mutation>> captor =
+        org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+    verify(mockDatabaseClient).write(captor.capture());
+    assertThat(captor.getValue().get(0).getOperation()).isEqualTo(Mutation.Op.INSERT);
+  }
+
+  @Test
+  public void testMutationTypeLowerCaseIsHonored() throws IOException {
+    // Simulate what happens when CaseInsensitiveStringMap lowercases keys:
+    // the key becomes "mutationtype" instead of "mutationType".
+    properties.put("mutationtype", "insert");
+    try (SpannerDataWriter writer = createWriter(properties)) {
+      when(mockDatabaseClient.write(any())).thenReturn(null);
+      writer.write(CreateInternalRow(1L));
+      writer.commit();
+    }
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<java.util.List<Mutation>> captor =
+        org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+    verify(mockDatabaseClient).write(captor.capture());
+    assertThat(captor.getValue().get(0).getOperation()).isEqualTo(Mutation.Op.INSERT);
   }
 
   private InternalRow CreateInternalRow(long i) {

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerDataWriterTestBase.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerDataWriterTestBase.java
@@ -426,9 +426,8 @@ public abstract class SpannerDataWriterTestBase {
     }
   }
 
-  @Test
-  public void testMutationTypeCamelCaseIsHonored() throws IOException {
-    properties.put("mutationType", "insert");
+  private void testMutationTypeIsHonored(String mutationTypeKey) throws IOException {
+    properties.put(mutationTypeKey, "insert");
     try (SpannerDataWriter writer = createWriter(properties)) {
       when(mockDatabaseClient.write(any())).thenReturn(null);
       writer.write(CreateInternalRow(1L));
@@ -437,27 +436,21 @@ public abstract class SpannerDataWriterTestBase {
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<java.util.List<Mutation>> captor =
-        org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+            org.mockito.ArgumentCaptor.forClass(java.util.List.class);
     verify(mockDatabaseClient).write(captor.capture());
     assertThat(captor.getValue().get(0).getOperation()).isEqualTo(Mutation.Op.INSERT);
+  }
+
+  @Test
+  public void testMutationTypeCamelCaseIsHonored() throws IOException {
+    testMutationTypeIsHonored("mutationType");
   }
 
   @Test
   public void testMutationTypeLowerCaseIsHonored() throws IOException {
     // Simulate what happens when CaseInsensitiveStringMap lowercases keys:
     // the key becomes "mutationtype" instead of "mutationType".
-    properties.put("mutationtype", "insert");
-    try (SpannerDataWriter writer = createWriter(properties)) {
-      when(mockDatabaseClient.write(any())).thenReturn(null);
-      writer.write(CreateInternalRow(1L));
-      writer.commit();
-    }
-
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<java.util.List<Mutation>> captor =
-        org.mockito.ArgumentCaptor.forClass(java.util.List.class);
-    verify(mockDatabaseClient).write(captor.capture());
-    assertThat(captor.getValue().get(0).getOperation()).isEqualTo(Mutation.Op.INSERT);
+    testMutationTypeIsHonored("mutationtype");
   }
 
   private InternalRow CreateInternalRow(long i) {

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerDataWriterTestBase.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SpannerDataWriterTestBase.java
@@ -436,7 +436,7 @@ public abstract class SpannerDataWriterTestBase {
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<java.util.List<Mutation>> captor =
-            org.mockito.ArgumentCaptor.forClass(java.util.List.class);
+        org.mockito.ArgumentCaptor.forClass(java.util.List.class);
     verify(mockDatabaseClient).write(captor.capture());
     assertThat(captor.getValue().get(0).getOperation()).isEqualTo(Mutation.Op.INSERT);
   }


### PR DESCRIPTION
This way `mutationType` and `mutationtype` will both be accepted. Discovered during testing that the key is lower-cased when using PySpark.