### PR TITLE
Spark 4.0 disable acceptance tests via property failsafe.exclude.pattern

### DIFF
--- a/spark-4.0-spanner-lib/pom.xml
+++ b/spark-4.0-spanner-lib/pom.xml
@@ -18,7 +18,7 @@
     <shade.skip>true</shade.skip>
     <toolchain.jdk.version>[17,18)</toolchain.jdk.version>
     <maven.compiler.release>17</maven.compiler.release>
-    <failsafe.exclude.pattern></failsafe.exclude.pattern>
+    <spark40.acceptance.exclude.pattern>**/*AcceptanceTest.java</spark40.acceptance.exclude.pattern>
   </properties>
   <licenses>
     <license>
@@ -119,7 +119,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <excludes>
-                <exclude>${failsafe.exclude.pattern}</exclude>
+                <exclude>${spark40.acceptance.exclude.pattern}</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/spark-4.0-spanner-lib/pom.xml
+++ b/spark-4.0-spanner-lib/pom.xml
@@ -18,6 +18,7 @@
     <shade.skip>true</shade.skip>
     <toolchain.jdk.version>[17,18)</toolchain.jdk.version>
     <maven.compiler.release>17</maven.compiler.release>
+    <failsafe.exclude.pattern></failsafe.exclude.pattern>
   </properties>
   <licenses>
     <license>
@@ -102,6 +103,25 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>acceptance</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>${failsafe.exclude.pattern}</exclude>
+              </excludes>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Added a property to disable the 4.0 acceptance tests. 

By default only the 4.0 acceptance tests, will not run. All other Spark versions will continue to run.

./mvnw integration-test  -P4.0,acceptance 

To enable the 4.0 acceptance tests define the `spark40.acceptance.exclude.pattern` property as follows:

./mvnw integration-test  -P4.0,acceptance -Dspark40.acceptance.exclude.pattern=""

This ensures the 4.0 acceptance tests will run. 