### PR TITLE
Pushdown abstract syntax tree

### DIFF
--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/AndExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/AndExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class AndExpr implements BoolExpr {
   private final BoolExpr left;
   private final BoolExpr right;
 
   public AndExpr(BoolExpr left, BoolExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public BoolExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/AndExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/AndExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class AndExpr implements BoolExpr {
+  private final BoolExpr left;
+  private final BoolExpr right;
+
+  public AndExpr(BoolExpr left, BoolExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public BoolExpr getLeft() {
+    return left;
+  }
+
+  public BoolExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/AndExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/AndExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class AndExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ArithmeticExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ArithmeticExpr.java
@@ -16,21 +16,24 @@ package com.google.cloud.spark.spanner.planning.expression;
 
 import java.util.Objects;
 
-public final class ContainsExpr implements BoolExpr {
-  private final ValueExpr left;
-  private final ValueExpr value;
+public final class ArithmeticExpr implements ValueExpr {
 
-  public ContainsExpr(ValueExpr left, ValueExpr value) {
+  public enum Operator {
+    ADD,
+    SUBTRACT,
+    MULTIPLY,
+    DIVIDE,
+    MOD
+  }
+
+  Operator operator;
+  ValueExpr left;
+  ValueExpr right;
+
+  public ArithmeticExpr(ValueExpr left, Operator operator, ValueExpr right) {
     this.left = Objects.requireNonNull(left, "left cannot be null");
-    this.value = Objects.requireNonNull(value, "value cannot be null");
-  }
-
-  public ValueExpr getLeft() {
-    return left;
-  }
-
-  public ValueExpr getValue() {
-    return value;
+    this.operator = Objects.requireNonNull(operator, "operator cannot be null");
+    this.right = Objects.requireNonNull(right, "left cannot be null");
   }
 
   @Override

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ArithmeticExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ArithmeticExpr.java
@@ -33,7 +33,7 @@ public final class ArithmeticExpr implements ValueExpr {
   public ArithmeticExpr(ValueExpr left, Operator operator, ValueExpr right) {
     this.left = Objects.requireNonNull(left, "left cannot be null");
     this.operator = Objects.requireNonNull(operator, "operator cannot be null");
-    this.right = Objects.requireNonNull(right, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   @Override

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/BoolExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/BoolExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public interface BoolExpr extends SpannerExpr {}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/BoolExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/BoolExpr.java
@@ -1,0 +1,3 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public interface BoolExpr extends SpannerExpr {}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/BoolExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/BoolExpr.java
@@ -14,4 +14,4 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
-public interface BoolExpr extends SpannerExpr {}
+public interface BoolExpr extends ValueExpr {}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
@@ -14,9 +14,8 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
-import org.apache.spark.sql.types.DataType;
-
 import java.util.Objects;
+import org.apache.spark.sql.types.DataType;
 
 public final class ColumnExpr implements ValueExpr {
   private final String columnName;

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 import org.apache.spark.sql.types.DataType;
@@ -5,6 +19,13 @@ import org.apache.spark.sql.types.DataType;
 public final class ColumnExpr implements ValueExpr {
   private final String columnName;
   private final DataType sparkType;
+  private final boolean nullable;
+
+  public ColumnExpr(String columnName, DataType sparkType, boolean nullable) {
+    this.columnName = columnName;
+    this.sparkType = sparkType;
+    this.nullable = nullable;
+  }
 
   public boolean isNullable() {
     return nullable;
@@ -12,14 +33,6 @@ public final class ColumnExpr implements ValueExpr {
 
   public DataType getSparkType() {
     return sparkType;
-  }
-
-  private final boolean nullable;
-
-  public ColumnExpr(String columnName, DataType sparkType, boolean nullable) {
-    this.columnName = columnName;
-    this.sparkType = sparkType;
-    this.nullable = nullable;
   }
 
   public String getColumnName() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
@@ -16,14 +16,16 @@ package com.google.cloud.spark.spanner.planning.expression;
 
 import org.apache.spark.sql.types.DataType;
 
+import java.util.Objects;
+
 public final class ColumnExpr implements ValueExpr {
   private final String columnName;
   private final DataType sparkType;
   private final boolean nullable;
 
   public ColumnExpr(String columnName, DataType sparkType, boolean nullable) {
-    this.columnName = columnName;
-    this.sparkType = sparkType;
+    this.columnName = Objects.requireNonNull(columnName, "columnName cannot be null");
+    this.sparkType = Objects.requireNonNull(sparkType, "sparkType cannot be null");
     this.nullable = nullable;
   }
 

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ColumnExpr.java
@@ -1,0 +1,33 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+import org.apache.spark.sql.types.DataType;
+
+public final class ColumnExpr implements ValueExpr {
+  private final String columnName;
+  private final DataType sparkType;
+
+  public boolean isNullable() {
+    return nullable;
+  }
+
+  public DataType getSparkType() {
+    return sparkType;
+  }
+
+  private final boolean nullable;
+
+  public ColumnExpr(String columnName, DataType sparkType, boolean nullable) {
+    this.columnName = columnName;
+    this.sparkType = sparkType;
+    this.nullable = nullable;
+  }
+
+  public String getColumnName() {
+    return columnName;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ContainsExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ContainsExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class ContainsExpr implements BoolExpr {
+  private final ColumnExpr left;
+  private final LiteralExpr value;
+
+  public ContainsExpr(ColumnExpr left, LiteralExpr value) {
+    this.left = left;
+    this.value = value;
+  }
+
+  public ColumnExpr getLeft() {
+    return left;
+  }
+
+  public LiteralExpr getValue() {
+    return value;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ContainsExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ContainsExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class ContainsExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ContainsExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ContainsExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class ContainsExpr implements BoolExpr {
   private final ColumnExpr left;
   private final LiteralExpr value;
 
   public ContainsExpr(ColumnExpr left, LiteralExpr value) {
-    this.left = left;
-    this.value = value;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.value = Objects.requireNonNull(value, "value cannot be null");
   }
 
   public ColumnExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class EndsWithExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class EndsWithExpr implements BoolExpr {
+  private final ColumnExpr left;
+  private final LiteralExpr suffix;
+
+  public EndsWithExpr(ColumnExpr left, LiteralExpr suffix) {
+    this.left = left;
+    this.suffix = suffix;
+  }
+
+  public ColumnExpr getLeft() {
+    return left;
+  }
+
+  public LiteralExpr getSuffix() {
+    return suffix;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
@@ -17,19 +17,19 @@ package com.google.cloud.spark.spanner.planning.expression;
 import java.util.Objects;
 
 public final class EndsWithExpr implements BoolExpr {
-  private final ColumnExpr left;
-  private final LiteralExpr suffix;
+  private final ValueExpr left;
+  private final ValueExpr suffix;
 
-  public EndsWithExpr(ColumnExpr left, LiteralExpr suffix) {
+  public EndsWithExpr(ValueExpr left, ValueExpr suffix) {
     this.left = Objects.requireNonNull(left, "left cannot be null");
     this.suffix = Objects.requireNonNull(suffix, "suffix cannot be null");
   }
 
-  public ColumnExpr getLeft() {
+  public ValueExpr getLeft() {
     return left;
   }
 
-  public LiteralExpr getSuffix() {
+  public ValueExpr getSuffix() {
     return suffix;
   }
 

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EndsWithExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class EndsWithExpr implements BoolExpr {
   private final ColumnExpr left;
   private final LiteralExpr suffix;
 
   public EndsWithExpr(ColumnExpr left, LiteralExpr suffix) {
-    this.left = left;
-    this.suffix = suffix;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.suffix = Objects.requireNonNull(suffix, "suffix cannot be null");
   }
 
   public ColumnExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class EqExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class EqExpr implements BoolExpr {
+  private final ValueExpr left;
+  private final ValueExpr right;
+
+  public EqExpr(ValueExpr left, ValueExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public ValueExpr getLeft() {
+    return left;
+  }
+
+  public ValueExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class EqExpr implements BoolExpr {
   private final ValueExpr left;
   private final ValueExpr right;
 
   public EqExpr(ValueExpr left, ValueExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public ValueExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqNullSafeExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqNullSafeExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class EqNullSafeExpr implements BoolExpr {
   private final ValueExpr left;
   private final ValueExpr right;
 
   public EqNullSafeExpr(ValueExpr left, ValueExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public ValueExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqNullSafeExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqNullSafeExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class EqNullSafeExpr implements BoolExpr {
+  private final ValueExpr left;
+  private final ValueExpr right;
+
+  public EqNullSafeExpr(ValueExpr left, ValueExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public ValueExpr getLeft() {
+    return left;
+  }
+
+  public ValueExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqNullSafeExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/EqNullSafeExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class EqNullSafeExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/FunctionExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/FunctionExpr.java
@@ -1,0 +1,85 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner.planning.expression;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class FunctionExpr implements ValueExpr {
+
+  public enum Function {
+    LOWER(1),
+    UPPER(1),
+    TRIM(1),
+    LENGTH(1),
+
+    CONCAT(2, Integer.MAX_VALUE),
+    COALESCE(2, Integer.MAX_VALUE),
+    GREATEST(2, Integer.MAX_VALUE),
+    LEAST(2, Integer.MAX_VALUE);
+
+    private final int minArgs;
+    private final int maxArgs;
+
+    Function(int exactArgs) {
+      this(exactArgs, exactArgs);
+    }
+
+    Function(int minArgs, int maxArgs) {
+      this.minArgs = minArgs;
+      this.maxArgs = maxArgs;
+    }
+
+    public void validate(List<ValueExpr> arguments) {
+      int count = arguments.size();
+
+      if (count < minArgs || count > maxArgs) {
+        throw new IllegalArgumentException(
+            String.format(
+                "%s expects between %d and %d arguments, received %d",
+                this, minArgs, maxArgs == Integer.MAX_VALUE ? Integer.MAX_VALUE : maxArgs, count));
+      }
+    }
+  }
+
+  private final Function function;
+  private final List<ValueExpr> arguments;
+
+  public FunctionExpr(Function function, List<ValueExpr> arguments) {
+
+    this.function = Objects.requireNonNull(function, "function cannot be null");
+
+    this.arguments =
+        Collections.unmodifiableList(
+            new ArrayList<>(Objects.requireNonNull(arguments, "arguments cannot be null")));
+
+    function.validate(this.arguments);
+  }
+
+  public Function function() {
+    return function;
+  }
+
+  public List<ValueExpr> arguments() {
+    return arguments;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GtExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GtExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class GtExpr implements BoolExpr {
+  private final ValueExpr left;
+  private final ValueExpr right;
+
+  public GtExpr(ValueExpr left, ValueExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public ValueExpr getLeft() {
+    return left;
+  }
+
+  public ValueExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GtExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GtExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class GtExpr implements BoolExpr {
   private final ValueExpr left;
   private final ValueExpr right;
 
   public GtExpr(ValueExpr left, ValueExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public ValueExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GtExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GtExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class GtExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GteExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GteExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class GteExpr implements BoolExpr {
   private final ValueExpr left;
   private final ValueExpr right;
 
   public GteExpr(ValueExpr left, ValueExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public ValueExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GteExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GteExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class GteExpr implements BoolExpr {
+  private final ValueExpr left;
+  private final ValueExpr right;
+
+  public GteExpr(ValueExpr left, ValueExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public ValueExpr getLeft() {
+    return left;
+  }
+
+  public ValueExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GteExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/GteExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class GteExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/InExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/InExpr.java
@@ -19,19 +19,19 @@ import java.util.List;
 import java.util.Objects;
 
 public final class InExpr implements BoolExpr {
-  private final ColumnExpr left;
-  private final List<LiteralExpr> values;
+  private final ValueExpr left;
+  private final List<ValueExpr> values;
 
-  public InExpr(ColumnExpr left, List<LiteralExpr> values) {
+  public InExpr(ValueExpr left, List<ValueExpr> values) {
     this.left = Objects.requireNonNull(left, "left cannot be null");
     this.values = ImmutableList.copyOf(Objects.requireNonNull(values, "values cannot be null"));
   }
 
-  public ColumnExpr getLeft() {
+  public ValueExpr getLeft() {
     return left;
   }
 
-  public List<LiteralExpr> getValues() {
+  public List<ValueExpr> getValues() {
     return values;
   }
 

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/InExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/InExpr.java
@@ -1,0 +1,26 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+import java.util.List;
+
+public final class InExpr implements BoolExpr {
+  private final ColumnExpr left;
+  private final List<LiteralExpr> values;
+
+  public InExpr(ColumnExpr left, List<LiteralExpr> values) {
+    this.left = left;
+    this.values = values;
+  }
+
+  public ColumnExpr getLeft() {
+    return left;
+  }
+
+  public List<LiteralExpr> getValues() {
+    return values;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/InExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/InExpr.java
@@ -1,14 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 
 public final class InExpr implements BoolExpr {
   private final ColumnExpr left;
   private final List<LiteralExpr> values;
 
   public InExpr(ColumnExpr left, List<LiteralExpr> values) {
-    this.left = left;
-    this.values = values;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.values = ImmutableList.copyOf(Objects.requireNonNull(values, "values cannot be null"));
   }
 
   public ColumnExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNotNullExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNotNullExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class IsNotNullExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNotNullExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNotNullExpr.java
@@ -1,0 +1,18 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class IsNotNullExpr implements BoolExpr {
+  private final ValueExpr value;
+
+  public IsNotNullExpr(ValueExpr value) {
+    this.value = value;
+  }
+
+  public ValueExpr getValue() {
+    return value;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNotNullExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNotNullExpr.java
@@ -14,11 +14,13 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class IsNotNullExpr implements BoolExpr {
   private final ValueExpr value;
 
   public IsNotNullExpr(ValueExpr value) {
-    this.value = value;
+    this.value = Objects.requireNonNull(value, "value cannot be null");
   }
 
   public ValueExpr getValue() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNullExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNullExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class IsNullExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNullExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNullExpr.java
@@ -14,11 +14,13 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class IsNullExpr implements BoolExpr {
   private final ValueExpr value;
 
   public IsNullExpr(ValueExpr value) {
-    this.value = value;
+    this.value = Objects.requireNonNull(value, "value cannot be null");
   }
 
   public ValueExpr getValue() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNullExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/IsNullExpr.java
@@ -1,0 +1,18 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class IsNullExpr implements BoolExpr {
+  private final ValueExpr value;
+
+  public IsNullExpr(ValueExpr value) {
+    this.value = value;
+  }
+
+  public ValueExpr getValue() {
+    return value;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LiteralExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LiteralExpr.java
@@ -1,0 +1,26 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+import org.apache.spark.sql.types.DataType;
+
+public final class LiteralExpr implements ValueExpr {
+
+  private final Object value;
+  private final DataType sparkType;
+
+  public LiteralExpr(Object value, DataType sparkType) {
+    this.value = value;
+    this.sparkType = sparkType;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  public DataType getSparkType() {
+    return sparkType;
+  }
+
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LiteralExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LiteralExpr.java
@@ -1,5 +1,20 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
 import org.apache.spark.sql.types.DataType;
 
 public final class LiteralExpr implements ValueExpr {
@@ -9,7 +24,7 @@ public final class LiteralExpr implements ValueExpr {
 
   public LiteralExpr(Object value, DataType sparkType) {
     this.value = value;
-    this.sparkType = sparkType;
+    this.sparkType = Objects.requireNonNull(sparkType, "sparkType cannot be null");
   }
 
   public Object getValue() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LtExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LtExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class LtExpr implements BoolExpr {
   private final ValueExpr left;
   private final ValueExpr right;
 
   public LtExpr(ValueExpr left, ValueExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public ValueExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LtExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LtExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class LtExpr implements BoolExpr {
+  private final ValueExpr left;
+  private final ValueExpr right;
+
+  public LtExpr(ValueExpr left, ValueExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public ValueExpr getLeft() {
+    return left;
+  }
+
+  public ValueExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LtExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LtExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class LtExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LteExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LteExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class LteExpr implements BoolExpr {
+  private final ValueExpr left;
+  private final ValueExpr right;
+
+  public LteExpr(ValueExpr left, ValueExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public ValueExpr getLeft() {
+    return left;
+  }
+
+  public ValueExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LteExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LteExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class LteExpr implements BoolExpr {
   private final ValueExpr left;
   private final ValueExpr right;
 
   public LteExpr(ValueExpr left, ValueExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public ValueExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LteExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/LteExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class LteExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/NotExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/NotExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class NotExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/NotExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/NotExpr.java
@@ -14,11 +14,13 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class NotExpr implements BoolExpr {
   private final BoolExpr value;
 
   public NotExpr(BoolExpr value) {
-    this.value = value;
+    this.value = Objects.requireNonNull(value, "value cannot be null");
   }
 
   public BoolExpr getValue() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/NotExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/NotExpr.java
@@ -1,0 +1,18 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class NotExpr implements BoolExpr {
+  private final BoolExpr value;
+
+  public NotExpr(BoolExpr value) {
+    this.value = value;
+  }
+
+  public BoolExpr getValue() {
+    return value;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/OrExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/OrExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class OrExpr implements BoolExpr {
   private final BoolExpr left;
   private final BoolExpr right;
 
   public OrExpr(BoolExpr left, BoolExpr right) {
-    this.left = left;
-    this.right = right;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.right = Objects.requireNonNull(right, "right cannot be null");
   }
 
   public BoolExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/OrExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/OrExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class OrExpr implements BoolExpr {
+  private final BoolExpr left;
+  private final BoolExpr right;
+
+  public OrExpr(BoolExpr left, BoolExpr right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  public BoolExpr getLeft() {
+    return left;
+  }
+
+  public BoolExpr getRight() {
+    return right;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/OrExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/OrExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class OrExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExpr.java
@@ -1,0 +1,7 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+import java.io.Serializable;
+
+public interface SpannerExpr extends Serializable {
+  <T> T accept(SpannerExprVisitor<T> visitor);
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExpr.java
@@ -14,8 +14,6 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
-import java.io.Serializable;
-
-public interface SpannerExpr extends Serializable {
+public interface SpannerExpr {
   <T> T accept(SpannerExprVisitor<T> visitor);
 }

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 import java.io.Serializable;

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExprVisitor.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExprVisitor.java
@@ -50,4 +50,8 @@ public interface SpannerExprVisitor<T> {
   T visit(EndsWithExpr expr);
 
   T visit(ContainsExpr expr);
+
+  T visit(ArithmeticExpr expr);
+
+  T visit(FunctionExpr expr);
 }

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExprVisitor.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExprVisitor.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public interface SpannerExprVisitor<T> {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExprVisitor.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/SpannerExprVisitor.java
@@ -1,0 +1,39 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public interface SpannerExprVisitor<T> {
+  T visit(EqExpr expr);
+
+  T visit(EqNullSafeExpr expr);
+
+  T visit(GtExpr expr);
+
+  T visit(GteExpr expr);
+
+  T visit(LtExpr expr);
+
+  T visit(LteExpr expr);
+
+  T visit(AndExpr expr);
+
+  T visit(OrExpr expr);
+
+  T visit(ColumnExpr expr);
+
+  T visit(LiteralExpr expr);
+
+  T visit(TrueExpr expr);
+
+  T visit(IsNullExpr expr);
+
+  T visit(IsNotNullExpr expr);
+
+  T visit(InExpr expr);
+
+  T visit(NotExpr expr);
+
+  T visit(StartsWithExpr expr);
+
+  T visit(EndsWithExpr expr);
+
+  T visit(ContainsExpr expr);
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
@@ -14,13 +14,15 @@
 
 package com.google.cloud.spark.spanner.planning.expression;
 
+import java.util.Objects;
+
 public final class StartsWithExpr implements BoolExpr {
   private final ColumnExpr left;
   private final LiteralExpr prefix;
 
   public StartsWithExpr(ColumnExpr left, LiteralExpr prefix) {
-    this.left = left;
-    this.prefix = prefix;
+    this.left = Objects.requireNonNull(left, "left cannot be null");
+    this.prefix = Objects.requireNonNull(prefix, "prefix cannot be null");
   }
 
   public ColumnExpr getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class StartsWithExpr implements BoolExpr {
+  private final ColumnExpr left;
+  private final LiteralExpr prefix;
+
+  public StartsWithExpr(ColumnExpr left, LiteralExpr prefix) {
+    this.left = left;
+    this.prefix = prefix;
+  }
+
+  public ColumnExpr getLeft() {
+    return left;
+  }
+
+  public LiteralExpr getPrefix() {
+    return prefix;
+  }
+
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
@@ -17,19 +17,19 @@ package com.google.cloud.spark.spanner.planning.expression;
 import java.util.Objects;
 
 public final class StartsWithExpr implements BoolExpr {
-  private final ColumnExpr left;
-  private final LiteralExpr prefix;
+  private final ValueExpr left;
+  private final ValueExpr prefix;
 
-  public StartsWithExpr(ColumnExpr left, LiteralExpr prefix) {
+  public StartsWithExpr(ValueExpr left, ValueExpr prefix) {
     this.left = Objects.requireNonNull(left, "left cannot be null");
     this.prefix = Objects.requireNonNull(prefix, "prefix cannot be null");
   }
 
-  public ColumnExpr getLeft() {
+  public ValueExpr getLeft() {
     return left;
   }
 
-  public LiteralExpr getPrefix() {
+  public ValueExpr getPrefix() {
     return prefix;
   }
 

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/StartsWithExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class StartsWithExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/TrueExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/TrueExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public final class TrueExpr implements BoolExpr {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/TrueExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/TrueExpr.java
@@ -1,0 +1,8 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public final class TrueExpr implements BoolExpr {
+  @Override
+  public <T> T accept(SpannerExprVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ValueExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ValueExpr.java
@@ -1,0 +1,3 @@
+package com.google.cloud.spark.spanner.planning.expression;
+
+public interface ValueExpr extends SpannerExpr {}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ValueExpr.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/expression/ValueExpr.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.expression;
 
 public interface ValueExpr extends SpannerExpr {}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinRelation.java
@@ -27,7 +27,7 @@ public final class JoinRelation implements Relation {
     this.left = Objects.requireNonNull(left, "left relation cannot be null");
     this.right = Objects.requireNonNull(right, "right relation cannot be null");
     this.joinType = Objects.requireNonNull(joinType, "joinType cannot be null");
-    this.condition = condition;
+    this.condition = Objects.requireNonNull(condition, "condition cannot be null");
   }
 
   public Relation getLeft() {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinRelation.java
@@ -1,0 +1,38 @@
+package com.google.cloud.spark.spanner.planning.relation;
+
+import com.google.cloud.spark.spanner.planning.expression.BoolExpr;
+
+public final class JoinRelation implements Relation {
+  private final Relation left;
+  private final Relation right;
+  private final JoinType joinType;
+  private final BoolExpr condition;
+
+  public BoolExpr getCondition() {
+    return condition;
+  }
+
+  public JoinType getJoinType() {
+    return joinType;
+  }
+
+  public Relation getRight() {
+    return right;
+  }
+
+  public Relation getLeft() {
+    return left;
+  }
+
+  public JoinRelation(Relation left, Relation right, JoinType joinType, BoolExpr condition) {
+    this.left = left;
+    this.right = right;
+    this.joinType = joinType;
+    this.condition = condition;
+  }
+
+  @Override
+  public <T> T accept(RelationVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinRelation.java
@@ -1,6 +1,21 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.relation;
 
 import com.google.cloud.spark.spanner.planning.expression.BoolExpr;
+import java.util.Objects;
 
 public final class JoinRelation implements Relation {
   private final Relation left;
@@ -8,27 +23,27 @@ public final class JoinRelation implements Relation {
   private final JoinType joinType;
   private final BoolExpr condition;
 
-  public BoolExpr getCondition() {
-    return condition;
-  }
-
-  public JoinType getJoinType() {
-    return joinType;
-  }
-
-  public Relation getRight() {
-    return right;
+  public JoinRelation(Relation left, Relation right, JoinType joinType, BoolExpr condition) {
+    this.left = Objects.requireNonNull(left, "left relation cannot be null");
+    this.right = Objects.requireNonNull(right, "right relation cannot be null");
+    this.joinType = Objects.requireNonNull(joinType, "joinType cannot be null");
+    this.condition = condition;
   }
 
   public Relation getLeft() {
     return left;
   }
 
-  public JoinRelation(Relation left, Relation right, JoinType joinType, BoolExpr condition) {
-    this.left = left;
-    this.right = right;
-    this.joinType = joinType;
-    this.condition = condition;
+  public Relation getRight() {
+    return right;
+  }
+
+  public JoinType getJoinType() {
+    return joinType;
+  }
+
+  public BoolExpr getCondition() {
+    return condition;
   }
 
   @Override

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinType.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinType.java
@@ -1,0 +1,8 @@
+package com.google.cloud.spark.spanner.planning.relation;
+
+public enum JoinType {
+  INNER,
+  LEFT_OUTER,
+  RIGHT_OUTER,
+  FULL_OUTER
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinType.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/JoinType.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.relation;
 
 public enum JoinType {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/Relation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/Relation.java
@@ -1,0 +1,7 @@
+package com.google.cloud.spark.spanner.planning.relation;
+
+import java.io.Serializable;
+
+public interface Relation extends Serializable {
+  <T> T accept(RelationVisitor<T> visitor);
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/Relation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/Relation.java
@@ -14,8 +14,6 @@
 
 package com.google.cloud.spark.spanner.planning.relation;
 
-import java.io.Serializable;
-
-public interface Relation extends Serializable {
+public interface Relation {
   <T> T accept(RelationVisitor<T> visitor);
 }

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/Relation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/Relation.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.relation;
 
 import java.io.Serializable;

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/RelationVisitor.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/RelationVisitor.java
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.relation;
 
 public interface RelationVisitor<T> {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/RelationVisitor.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/RelationVisitor.java
@@ -1,0 +1,7 @@
+package com.google.cloud.spark.spanner.planning.relation;
+
+public interface RelationVisitor<T> {
+  T visit(TableRelation relation);
+
+  T visit(JoinRelation relation);
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
@@ -1,9 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.cloud.spark.spanner.planning.relation;
 
 import com.google.cloud.spark.spanner.scan.SpannerTable;
 
 public final class TableRelation implements Relation {
   private final String tableName;
+  private final String alias;
+  private final SpannerTable table;
+
+  public TableRelation(String tableName, String alias, SpannerTable table) {
+    this.tableName = tableName;
+    this.alias = alias;
+    this.table = table;
+  }
 
   public String getAlias() {
     return alias;
@@ -15,16 +37,6 @@ public final class TableRelation implements Relation {
 
   public SpannerTable getTable() {
     return table;
-  }
-
-  private final String alias;
-
-  private final SpannerTable table;
-
-  public TableRelation(String tableName, String alias, SpannerTable table) {
-    this.tableName = tableName;
-    this.alias = alias;
-    this.table = table;
   }
 
   @Override

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
@@ -15,7 +15,6 @@
 package com.google.cloud.spark.spanner.planning.relation;
 
 import com.google.cloud.spark.spanner.scan.SpannerTable;
-
 import java.util.Objects;
 
 public final class TableRelation implements Relation {

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
@@ -23,7 +23,7 @@ public final class TableRelation implements Relation {
   private final SpannerTable table;
 
   public TableRelation(String tableName, String alias, SpannerTable table) {
-    this.tableName = tableName;
+    this.tableName = Objects.requireNonNull(tableName, "tableName cannot be null");
     this.alias = alias;
     this.table = Objects.requireNonNull(table, "table cannot be null");
   }

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
@@ -1,0 +1,34 @@
+package com.google.cloud.spark.spanner.planning.relation;
+
+import com.google.cloud.spark.spanner.scan.SpannerTable;
+
+public final class TableRelation implements Relation {
+  private final String tableName;
+
+  public String getAlias() {
+    return alias;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public SpannerTable getTable() {
+    return table;
+  }
+
+  private final String alias;
+
+  private final SpannerTable table;
+
+  public TableRelation(String tableName, String alias, SpannerTable table) {
+    this.tableName = tableName;
+    this.alias = alias;
+    this.table = table;
+  }
+
+  @Override
+  public <T> T accept(RelationVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/planning/relation/TableRelation.java
@@ -16,6 +16,8 @@ package com.google.cloud.spark.spanner.planning.relation;
 
 import com.google.cloud.spark.spanner.scan.SpannerTable;
 
+import java.util.Objects;
+
 public final class TableRelation implements Relation {
   private final String tableName;
   private final String alias;
@@ -24,7 +26,7 @@ public final class TableRelation implements Relation {
   public TableRelation(String tableName, String alias, SpannerTable table) {
     this.tableName = tableName;
     this.alias = alias;
-    this.table = table;
+    this.table = Objects.requireNonNull(table, "table cannot be null");
   }
 
   public String getAlias() {


### PR DESCRIPTION
This change represents an important component of the new pushdown infrastructure. The planned phases, each presented in seperate PRs are: 

1. Logical Query - separation of Spark query from Spanner backend. Existing PR approved and merged.
2. Abtract Syntax Tree (AST) - internal connector representation of the query. **This PR.**
3. Predicate to AST converter - converts Spark Predicates used by joins and V2 filters into the internal AST
4. AST to SQL rendering - SQL generation required for join pushdown
5. Spark SupportsPushDownJoin interface implementation.