### PR TITLE
Add table read timestamp support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+*   Add a `readTimestamp` option for reading tables from a consistent database snapshot.
 *   Add support for TPC-H benchmarking (framework integration and Databricks execution).
 *   Add integration test support for Spanner Omni.
 *   Add foundational changes for join pushdown support.

--- a/README-template.md
+++ b/README-template.md
@@ -177,6 +177,7 @@ instanceId|String|The instanceID of the Cloud Spanner database. For Spanner Omni
 databaseId|String|The databaseID of the Cloud Spanner database
 table|String|The Table of the Cloud Spanner database that you are reading from
 enableDataboost|Boolean|Enable the [Data Boost](https://cloud.google.com/spanner/docs/databoost/databoost-overview), which provides independent compute resources to query Spanner with near-zero impact to existing workloads. Note1: the option may trigger [extra charge](https://cloud.google.com/spanner/pricing#spanner-data-boost-pricing). Note2: this feature is not supported in Spanner Omni.
+readTimestamp|String|An RFC 3339 timestamp identifying the database snapshot to read. Multiple table reads using the same timestamp observe a consistent snapshot. By default, each table read uses the time when its scan is created.
 emulatorHost|String|The host and port of the Spanner emulator (e.g. `localhost:9010`) or a Spanner Omni instance (e.g. `localhost:15000`). When set, the connector connects to the emulator or Spanner Omni instead of Cloud Spanner. Useful for local development and testing.
 
 ### Writing to Spanner Tables

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ instanceId|String|The instanceID of the Cloud Spanner database
 databaseId|String|The databaseID of the Cloud Spanner database
 table|String|The Table of the Cloud Spanner database that you are reading from
 enableDataboost|Boolean|Enable the [Data Boost](https://cloud.google.com/spanner/docs/databoost/databoost-overview), which provides independent compute resources to query Spanner with near-zero impact to existing workloads. Note the option may trigger [extra charge](https://cloud.google.com/spanner/pricing#spanner-data-boost-pricing).
+readTimestamp|String|An RFC 3339 timestamp identifying the database snapshot to read. Multiple table reads using the same timestamp observe a consistent snapshot. By default, each table read uses the time when its scan is created.
 emulatorHost|String|The host and port of the Spanner emulator (e.g. `localhost:9010`). When set, the connector connects to the emulator instead of Cloud Spanner. Useful for local development and testing.
 
 ### Writing to Spanner Tables

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/scan/SpannerScanner.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/scan/SpannerScanner.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class SpannerScanner implements Batch, Scan {
   private final SpannerTable spannerTable;
   private final CaseInsensitiveStringMap opts;
-  private final Timestamp INIT_TIME = Timestamp.now();
+  private final TimestampBound readTimestamp;
   private final StructType readSchema;
   private final LogicalQuery logicalQuery;
   private static final Logger logger = LoggerFactory.getLogger(SpannerScanner.class);
@@ -49,6 +49,7 @@ public class SpannerScanner implements Batch, Scan {
   public SpannerScanner(LogicalQuery logicalQuery) {
     this.spannerTable = logicalQuery.getSource();
     this.opts = this.spannerTable.properties();
+    this.readTimestamp = getReadTimestamp(this.opts);
     this.readSchema =
         SpannerUtils.pruneSchema(this.spannerTable.schema(), logicalQuery.getProjections());
     this.logicalQuery = logicalQuery;
@@ -69,6 +70,12 @@ public class SpannerScanner implements Batch, Scan {
     return new SpannerPartitionReaderFactory();
   }
 
+  static TimestampBound getReadTimestamp(CaseInsensitiveStringMap options) {
+    String timestamp = options.get("readTimestamp");
+    return TimestampBound.ofReadTimestamp(
+        timestamp == null ? Timestamp.now() : Timestamp.parseTimestamp(timestamp));
+  }
+
   @Override
   public InputPartition[] planInputPartitions() {
 
@@ -83,8 +90,7 @@ public class SpannerScanner implements Batch, Scan {
     }
 
     try (BatchReadOnlyTransaction txn =
-        batchClient.batchClient.batchReadOnlyTransaction(
-            TimestampBound.ofReadTimestamp(INIT_TIME))) {
+        batchClient.batchClient.batchReadOnlyTransaction(readTimestamp)) {
       String mapAsJSON = SpannerUtils.serializeMap(this.opts);
       java.util.List<com.google.cloud.spanner.Partition> rawPartitions =
           txn.partitionQuery(

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/scan/SpannerScannerTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/scan/SpannerScannerTest.java
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.spark.spanner.scan;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.TimestampBound;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.Test;
+
+public class SpannerScannerTest {
+
+  @Test
+  public void configuredReadTimestampIsUsed() {
+    Timestamp timestamp = Timestamp.parseTimestamp("2026-07-14T12:34:56.123456Z");
+    Map<String, String> options = new HashMap<>();
+    options.put("readTimestamp", timestamp.toString());
+
+    TimestampBound timestampBound =
+        SpannerScanner.getReadTimestamp(new CaseInsensitiveStringMap(options));
+
+    assertEquals(timestamp, timestampBound.getReadTimestamp());
+  }
+
+  @Test
+  public void readTimestampOptionIsCaseInsensitive() {
+    Timestamp timestamp = Timestamp.parseTimestamp("2026-07-14T12:34:56Z");
+    Map<String, String> options = new HashMap<>();
+    options.put("readtimestamp", timestamp.toString());
+
+    TimestampBound timestampBound =
+        SpannerScanner.getReadTimestamp(new CaseInsensitiveStringMap(options));
+
+    assertEquals(timestamp, timestampBound.getReadTimestamp());
+  }
+}


### PR DESCRIPTION
## Summary

Add a `readTimestamp` option for ordinary Spanner table scans. The option accepts an RFC 3339 timestamp and uses it as the `TimestampBound` for the batch read-only transaction.

This brings table reads to parity with graph exports, which already support selecting a read timestamp. In particular, callers exporting several related tables can now give each independently partitioned scan the same timestamp and observe one consistent database snapshot.

When the option is omitted, the connector preserves its current behavior by using the time when the scan is created.

## Changes

- Parse the case-insensitive `readTimestamp` scan option.
- Use the resulting timestamp for partition generation.
- Add focused tests for timestamp selection and option case handling.
- Document the option in the generated and source README files and changelog.

## Testing

- Checkstyle passed.
- Spotless passed.
- Production and test source compilation passed.
- The focused Maven test reached Surefire, but could not execute locally because this machine only has Java 26 configured and the project requires a Java 8 test toolchain.
