### PR TITLE
Allow Spark to read partitionable Spanner SQL directly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+*   Add a `query` option for reading partitionable SQL query results as Spark DataFrames.
 *   Add a `readTimestamp` option for reading tables from a consistent database snapshot.
 *   Add support for TPC-H benchmarking (framework integration and Databricks execution).
 *   Add integration test support for Spanner Omni.

--- a/README-template.md
+++ b/README-template.md
@@ -175,10 +175,28 @@ Variable|Validation|Comments
 projectId|String|The projectID containing the Cloud Spanner database. For Spanner Omni this should always be `default`.
 instanceId|String|The instanceID of the Cloud Spanner database. For Spanner Omni this should always be `default`.
 databaseId|String|The databaseID of the Cloud Spanner database
-table|String|The Table of the Cloud Spanner database that you are reading from
+table|String|The Table of the Cloud Spanner database that you are reading from. Mutually exclusive with `query`.
+query|String|A root-partitionable, read-only SQL query whose results should be loaded as a Spark DataFrame. Mutually exclusive with `table`.
 enableDataboost|Boolean|Enable the [Data Boost](https://cloud.google.com/spanner/docs/databoost/databoost-overview), which provides independent compute resources to query Spanner with near-zero impact to existing workloads. Note1: the option may trigger [extra charge](https://cloud.google.com/spanner/pricing#spanner-data-boost-pricing). Note2: this feature is not supported in Spanner Omni.
 readTimestamp|String|An RFC 3339 timestamp identifying the database snapshot to read. Multiple table reads using the same timestamp observe a consistent snapshot. By default, each table read uses the time when its scan is created.
 emulatorHost|String|The host and port of the Spanner emulator (e.g. `localhost:9010`) or a Spanner Omni instance (e.g. `localhost:15000`). When set, the connector connects to the emulator or Spanner Omni instead of Cloud Spanner. Useful for local development and testing.
+
+#### Reading a SQL Query
+
+Provide `query` instead of `table` to load the results of a root-partitionable
+Spanner SQL query. The connector infers the DataFrame schema from the query
+result, partitions the query across Spark tasks, and supports the same
+`readTimestamp`, `enableDataBoost`, and `emulatorHost` options as table reads.
+Every output column must have a unique name, so computed expressions need aliases.
+
+```python
+df = spark.read.format('cloud-spanner') \
+   .option("projectId", "$YourProjectId") \
+   .option("instanceId", "$YourInstanceId") \
+   .option("databaseId", "$YourDatabaseId") \
+   .option("query", "SELECT UserId AS id, Name FROM Users WHERE Active") \
+   .load()
+```
 
 ### Writing to Spanner Tables
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,28 @@ Variable|Validation|Comments
 projectId|String|The projectID containing the Cloud Spanner database
 instanceId|String|The instanceID of the Cloud Spanner database
 databaseId|String|The databaseID of the Cloud Spanner database
-table|String|The Table of the Cloud Spanner database that you are reading from
+table|String|The Table of the Cloud Spanner database that you are reading from. Mutually exclusive with `query`.
+query|String|A root-partitionable, read-only SQL query whose results should be loaded as a Spark DataFrame. Mutually exclusive with `table`.
 enableDataboost|Boolean|Enable the [Data Boost](https://cloud.google.com/spanner/docs/databoost/databoost-overview), which provides independent compute resources to query Spanner with near-zero impact to existing workloads. Note the option may trigger [extra charge](https://cloud.google.com/spanner/pricing#spanner-data-boost-pricing).
 readTimestamp|String|An RFC 3339 timestamp identifying the database snapshot to read. Multiple table reads using the same timestamp observe a consistent snapshot. By default, each table read uses the time when its scan is created.
 emulatorHost|String|The host and port of the Spanner emulator (e.g. `localhost:9010`). When set, the connector connects to the emulator instead of Cloud Spanner. Useful for local development and testing.
+
+#### Reading a SQL Query
+
+Provide `query` instead of `table` to load the results of a root-partitionable
+Spanner SQL query. The connector infers the DataFrame schema from the query
+result, partitions the query across Spark tasks, and supports the same
+`readTimestamp`, `enableDataBoost`, and `emulatorHost` options as table reads.
+Every output column must have a unique name, so computed expressions need aliases.
+
+```python
+df = spark.read.format('cloud-spanner') \
+   .option("projectId", "$YourProjectId") \
+   .option("instanceId", "$YourInstanceId") \
+   .option("databaseId", "$YourDatabaseId") \
+   .option("query", "SELECT UserId AS id, Name FROM Users WHERE Active") \
+   .load()
+```
 
 ### Writing to Spanner Tables
 

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SparkSpannerTableProviderBase.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/SparkSpannerTableProviderBase.java
@@ -15,6 +15,7 @@
 package com.google.cloud.spark.spanner;
 
 import com.google.cloud.spark.spanner.graph.SpannerGraphBuilder;
+import com.google.cloud.spark.spanner.scan.SpannerQueryTable;
 import com.google.cloud.spark.spanner.scan.SpannerTable;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -57,14 +58,17 @@ public abstract class SparkSpannerTableProviderBase implements DataSourceRegiste
         Boolean.parseBoolean(options.getOrDefault("enablePartialRowUpdates", "false"));
     boolean hasTable = options.containsKey("table");
     boolean hasGraph = options.containsKey("graph");
-    if (hasTable && !hasGraph) {
+    boolean hasQuery = options.containsKey("query");
+    if (hasTable && !hasGraph && !hasQuery) {
       return new SpannerTable(options, schema);
-    } else if (!hasTable && hasGraph) {
+    } else if (!hasTable && hasGraph && !hasQuery) {
       return SpannerGraphBuilder.build(options);
+    } else if (!hasTable && !hasGraph && hasQuery) {
+      return new SpannerQueryTable(options);
     } else {
       throw new SpannerConnectorException(
           SpannerErrorCode.INVALID_ARGUMENT,
-          "properties must contain one of \"table\" or \"graph\"");
+          "properties must contain exactly one of \"table\", \"graph\", or \"query\"");
     }
   }
 
@@ -89,14 +93,17 @@ public abstract class SparkSpannerTableProviderBase implements DataSourceRegiste
   private Table getTable(Map<String, String> properties) {
     boolean hasTable = properties.containsKey("table");
     boolean hasGraph = properties.containsKey("graph");
-    if (hasTable && !hasGraph) {
+    boolean hasQuery = properties.containsKey("query");
+    if (hasTable && !hasGraph && !hasQuery) {
       return new SpannerTable(properties);
-    } else if (!hasTable && hasGraph) {
+    } else if (!hasTable && hasGraph && !hasQuery) {
       return SpannerGraphBuilder.build(properties);
+    } else if (!hasTable && !hasGraph && hasQuery) {
+      return new SpannerQueryTable(new CaseInsensitiveStringMap(properties));
     } else {
       throw new SpannerConnectorException(
           SpannerErrorCode.INVALID_ARGUMENT,
-          "properties must contain one of \"table\" or \"graph\"");
+          "properties must contain exactly one of \"table\", \"graph\", or \"query\"");
     }
   }
 

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/scan/SpannerQueryTable.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/scan/SpannerQueryTable.java
@@ -1,0 +1,140 @@
+package com.google.cloud.spark.spanner.scan;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.ReadContext.QueryAnalyzeMode;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.AbstractStatementParser;
+import com.google.cloud.spanner.connection.Connection;
+import com.google.cloud.spark.spanner.SpannerConnectorException;
+import com.google.cloud.spark.spanner.SpannerErrorCode;
+import com.google.cloud.spark.spanner.SpannerUtils;
+import com.google.common.collect.ImmutableSet;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeAnnotationCode;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import org.apache.spark.sql.connector.catalog.SupportsRead;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+public class SpannerQueryTable implements Table, SupportsRead {
+
+  private final CaseInsensitiveStringMap properties;
+  private final Statement statement;
+  private final StructType schema;
+
+  public SpannerQueryTable(CaseInsensitiveStringMap properties) {
+    String projectId = SpannerUtils.getRequiredOption(properties, "projectId");
+    String instanceId = SpannerUtils.getRequiredOption(properties, "instanceId");
+    String databaseId = SpannerUtils.getRequiredOption(properties, "databaseId");
+    String query = SpannerUtils.getRequiredOption(properties, "query");
+    this.properties = properties;
+    this.statement = Statement.of(query);
+
+    try (Connection connection =
+        SpannerUtils.connectionFromProperties(
+            projectId, instanceId, databaseId, properties.get("emulatorHost"))) {
+      validateQuery(statement, connection.getDialect());
+      connection.setReadOnly(true);
+      connection.setAutocommit(true);
+      connection.setReadOnlyStaleness(SpannerScanner.getReadTimestamp(properties));
+      try (ResultSet resultSet = connection.analyzeQuery(statement, QueryAnalyzeMode.PLAN)) {
+        this.schema = resultSetMetadataToSchema(resultSet.getMetadata());
+      }
+    }
+  }
+
+  static void validateQuery(Statement statement, Dialect dialect) {
+    AbstractStatementParser parser = AbstractStatementParser.getInstance(dialect);
+    if (!parser.isQuery(parser.removeCommentsAndTrim(statement.getSql()))) {
+      throw new SpannerConnectorException(
+          SpannerErrorCode.INVALID_ARGUMENT, "The query option must contain a read-only SQL query");
+    }
+  }
+
+  static StructType resultSetMetadataToSchema(ResultSetMetadata metadata) {
+    StructType result = new StructType();
+    Set<String> columnNames = new HashSet<>();
+    for (com.google.spanner.v1.StructType.Field field : metadata.getRowType().getFieldsList()) {
+      String name = field.getName();
+      if (name.isEmpty()) {
+        throw new SpannerConnectorException(
+            SpannerErrorCode.INVALID_ARGUMENT,
+            "Every query output column must have a name; use an alias for expressions");
+      }
+      if (!columnNames.add(name.toLowerCase(Locale.ROOT))) {
+        throw new SpannerConnectorException(
+            SpannerErrorCode.INVALID_ARGUMENT, "Duplicate query output column name: " + name);
+      }
+      result = result.add(toStructField(field));
+    }
+    return result;
+  }
+
+  private static StructField toStructField(com.google.spanner.v1.StructType.Field field) {
+    Type type = field.getType();
+    MetadataBuilder metadata = new MetadataBuilder();
+    if (type.getTypeAnnotation() == TypeAnnotationCode.PG_JSONB) {
+      metadata.putString(SpannerUtils.COLUMN_TYPE, "jsonb");
+    } else if (type.getCode() == com.google.spanner.v1.TypeCode.JSON) {
+      metadata.putString(SpannerUtils.COLUMN_TYPE, "json");
+    }
+    return new StructField(field.getName(), toSparkDataType(type), true, metadata.build());
+  }
+
+  private static DataType toSparkDataType(Type type) {
+    switch (type.getCode()) {
+      case ARRAY:
+        return DataTypes.createArrayType(toSparkDataType(type.getArrayElementType()), true);
+      case STRUCT:
+        StructType result = new StructType();
+        for (com.google.spanner.v1.StructType.Field field : type.getStructType().getFieldsList()) {
+          result = result.add(toStructField(field));
+        }
+        return result;
+      default:
+        DataType dataType = SpannerTable.ofSpannerStrType(type.getCode().name(), true);
+        if (!DataTypes.NullType.equals(dataType)) {
+          return dataType;
+        }
+        throw new SpannerConnectorException(
+            SpannerErrorCode.UNSUPPORTED_DATATYPE,
+            "Query output column type " + type.getCode() + " is not supported");
+    }
+  }
+
+  @Override
+  public String name() {
+    return "Spanner query";
+  }
+
+  @Override
+  public StructType schema() {
+    return schema;
+  }
+
+  @Override
+  public Set<TableCapability> capabilities() {
+    return ImmutableSet.of(TableCapability.BATCH_READ);
+  }
+
+  @Override
+  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+    return () -> new SpannerScanner(properties, schema, statement);
+  }
+
+  @Override
+  public CaseInsensitiveStringMap properties() {
+    return properties;
+  }
+}

--- a/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/scan/SpannerScanner.java
+++ b/spark-3.1-spanner-lib/src/main/java/com/google/cloud/spark/spanner/scan/SpannerScanner.java
@@ -19,12 +19,14 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.BatchReadOnlyTransaction;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.PartitionOptions;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spark.spanner.*;
 import com.google.cloud.spark.spanner.planning.query.LogicalQuery;
 import com.google.cloud.spark.spanner.rendering.SpannerQueryBuilder;
 import com.google.common.collect.Streams;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.spark.Partition;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.InputPartition;
@@ -39,20 +41,29 @@ import org.slf4j.LoggerFactory;
  * SpannerScanner implements Scan.
  */
 public class SpannerScanner implements Batch, Scan {
-  private final SpannerTable spannerTable;
   private final CaseInsensitiveStringMap opts;
   private final TimestampBound readTimestamp;
   private final StructType readSchema;
-  private final LogicalQuery logicalQuery;
+  private final @Nullable LogicalQuery logicalQuery;
+  private final @Nullable Statement statement;
   private static final Logger logger = LoggerFactory.getLogger(SpannerScanner.class);
 
   public SpannerScanner(LogicalQuery logicalQuery) {
-    this.spannerTable = logicalQuery.getSource();
-    this.opts = this.spannerTable.properties();
+    SpannerTable spannerTable = logicalQuery.getSource();
+    this.opts = spannerTable.properties();
     this.readTimestamp = getReadTimestamp(this.opts);
     this.readSchema =
-        SpannerUtils.pruneSchema(this.spannerTable.schema(), logicalQuery.getProjections());
+        SpannerUtils.pruneSchema(spannerTable.schema(), logicalQuery.getProjections());
     this.logicalQuery = logicalQuery;
+    this.statement = null;
+  }
+
+  public SpannerScanner(CaseInsensitiveStringMap options, StructType schema, Statement statement) {
+    this.opts = options;
+    this.readTimestamp = getReadTimestamp(options);
+    this.readSchema = schema;
+    this.logicalQuery = null;
+    this.statement = statement;
   }
 
   @Override
@@ -81,8 +92,11 @@ public class SpannerScanner implements Batch, Scan {
 
     BatchClientWithCloser batchClient = SpannerUtils.batchClientFromProperties(this.opts);
 
-    SpannerQueryBuilder result =
-        SpannerQueryBuilder.newBuilder(this.logicalQuery, batchClient.databaseClient.getDialect());
+    Statement query =
+        statement != null
+            ? statement
+            : SpannerQueryBuilder.newBuilder(logicalQuery, batchClient.databaseClient.getDialect())
+                .buildStatement();
 
     boolean enableDataboost = false;
     if (this.opts.containsKey("enableDataBoost")) {
@@ -95,7 +109,7 @@ public class SpannerScanner implements Batch, Scan {
       java.util.List<com.google.cloud.spanner.Partition> rawPartitions =
           txn.partitionQuery(
               PartitionOptions.getDefaultInstance(),
-              result.buildStatement(),
+              query,
               Options.dataBoostEnabled(enableDataboost));
 
       java.util.List<Partition> parts =

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SparkSpannerTableProviderBaseTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/SparkSpannerTableProviderBaseTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.spark.spanner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.Gson;
@@ -24,6 +25,7 @@ import com.google.gson.reflect.TypeToken;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -86,6 +88,50 @@ public class SparkSpannerTableProviderBaseTest {
             });
     Identifier identifier = provider.extractIdentifier(options);
     assertNull(identifier);
+  }
+
+  @Test
+  public void testExtractIdentifierWithQuery() {
+    TestSparkSpannerTableProvider provider = new TestSparkSpannerTableProvider();
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(
+            new HashMap<String, String>() {
+              {
+                put("query", "SELECT id FROM Users");
+              }
+            });
+
+    assertNull(provider.extractIdentifier(options));
+  }
+
+  @Test
+  public void testGetTableRejectsTableAndQuery() {
+    TestSparkSpannerTableProvider provider = new TestSparkSpannerTableProvider();
+    Map<String, String> properties = new HashMap<>();
+    properties.put("table", "Users");
+    properties.put("query", "SELECT id FROM Users");
+
+    SpannerConnectorException error =
+        assertThrows(
+            SpannerConnectorException.class,
+            () -> provider.getTable(new StructType(), null, properties));
+
+    assertTrue(error.getMessage().contains("exactly one"));
+  }
+
+  @Test
+  public void testInferSchemaRejectsGraphAndQuery() {
+    TestSparkSpannerTableProvider provider = new TestSparkSpannerTableProvider();
+    Map<String, String> properties = new HashMap<>();
+    properties.put("graph", "SocialGraph");
+    properties.put("query", "SELECT id FROM Users");
+
+    SpannerConnectorException error =
+        assertThrows(
+            SpannerConnectorException.class,
+            () -> provider.inferSchema(new CaseInsensitiveStringMap(properties)));
+
+    assertTrue(error.getMessage().contains("exactly one"));
   }
 
   @Test

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/integration/Spark31QueryReadIntegrationTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/integration/Spark31QueryReadIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.google.cloud.spark.spanner.integration;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.spark.spanner.SpannerConnectorException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.Test;
+
+public class Spark31QueryReadIntegrationTest extends SparkSpannerIntegrationTestBase {
+
+  @Test
+  public void readsPartitionableQueryWithAliasesAndFilters() {
+    Dataset<Row> dataframe = readQuery("SELECT A AS amount, B FROM ATable WHERE A >= 10");
+
+    assertThat(dataframe.columns()).asList().containsExactly("amount", "B").inOrder();
+    assertThat(dataframe.rdd().getNumPartitions()).isGreaterThan(0);
+    assertThat(dataframe.count()).isEqualTo(4);
+    assertThat(dataframe.filter("amount = 10").first().getLong(0)).isEqualTo(10);
+  }
+
+  @Test
+  public void infersArrayAndJsonResultSchemas() {
+    Dataset<Row> dataframe = readQuery("SELECT id, A, B, K FROM compositeTable WHERE id = 'id1'");
+
+    assertThat(dataframe.schema().apply("A").dataType())
+        .isEqualTo(DataTypes.createArrayType(DataTypes.LongType, true));
+    assertThat(dataframe.schema().apply("B").dataType())
+        .isEqualTo(DataTypes.createArrayType(DataTypes.StringType, true));
+    assertThat(dataframe.first().getList(1)).containsExactly(10L, 100L, 991L, 567282L).inOrder();
+    assertThat(dataframe.first().getString(3)).contains("\"a\":1");
+  }
+
+  @Test
+  public void queryCannotBeCombinedWithTable() {
+    Map<String, String> properties = connectionProperties();
+
+    assertThrows(
+        SpannerConnectorException.class,
+        () ->
+            spark
+                .read()
+                .format("cloud-spanner")
+                .options(properties)
+                .option("query", "SELECT A FROM ATable")
+                .load());
+  }
+
+  @Test
+  public void rejectsMutatingSql() {
+    assertThrows(SpannerConnectorException.class, () -> readQuery("DELETE FROM ATable WHERE true"));
+  }
+
+  private Dataset<Row> readQuery(String query) {
+    Map<String, String> properties = new HashMap<>(connectionProperties());
+    properties.remove("table");
+    return spark.read().format("cloud-spanner").options(properties).option("query", query).load();
+  }
+}

--- a/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/scan/SpannerQueryTableTest.java
+++ b/spark-3.1-spanner-lib/src/test/java/com/google/cloud/spark/spanner/scan/SpannerQueryTableTest.java
@@ -1,0 +1,162 @@
+package com.google.cloud.spark.spanner.scan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spark.spanner.SpannerConnectorException;
+import com.google.cloud.spark.spanner.SpannerErrorCode;
+import com.google.cloud.spark.spanner.SpannerUtils;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeAnnotationCode;
+import com.google.spanner.v1.TypeCode;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.Test;
+
+public class SpannerQueryTableTest {
+
+  @Test
+  public void validateQueryAcceptsSelectAndCommonTableExpressions() {
+    SpannerQueryTable.validateQuery(
+        Statement.of("SELECT id FROM Users"), Dialect.GOOGLE_STANDARD_SQL);
+    SpannerQueryTable.validateQuery(
+        Statement.of("WITH users AS (SELECT 1 AS id) SELECT id FROM users"),
+        Dialect.GOOGLE_STANDARD_SQL);
+    SpannerQueryTable.validateQuery(Statement.of("SELECT id FROM users"), Dialect.POSTGRESQL);
+  }
+
+  @Test
+  public void validateQueryRejectsMutations() {
+    SpannerConnectorException error =
+        assertThrows(
+            SpannerConnectorException.class,
+            () ->
+                SpannerQueryTable.validateQuery(
+                    Statement.of("DELETE FROM Users WHERE true"), Dialect.GOOGLE_STANDARD_SQL));
+
+    assertEquals(SpannerErrorCode.INVALID_ARGUMENT, error.getErrorCode());
+  }
+
+  @Test
+  public void resultSetMetadataToSchemaConvertsScalarTypes() {
+    ResultSetMetadata metadata =
+        metadata(
+            field("enabled", type(TypeCode.BOOL)),
+            field("payload", type(TypeCode.BYTES)),
+            field("created", type(TypeCode.DATE)),
+            field("score", type(TypeCode.FLOAT64)),
+            field("id", type(TypeCode.INT64)),
+            field("amount", type(TypeCode.NUMERIC)),
+            field("name", type(TypeCode.STRING)),
+            field("updated", type(TypeCode.TIMESTAMP)));
+
+    StructType schema = SpannerQueryTable.resultSetMetadataToSchema(metadata);
+
+    assertEquals(DataTypes.BooleanType, schema.apply("enabled").dataType());
+    assertEquals(DataTypes.BinaryType, schema.apply("payload").dataType());
+    assertEquals(DataTypes.DateType, schema.apply("created").dataType());
+    assertEquals(DataTypes.DoubleType, schema.apply("score").dataType());
+    assertEquals(DataTypes.LongType, schema.apply("id").dataType());
+    assertEquals(DataTypes.createDecimalType(38, 9), schema.apply("amount").dataType());
+    assertEquals(DataTypes.StringType, schema.apply("name").dataType());
+    assertEquals(DataTypes.TimestampType, schema.apply("updated").dataType());
+    assertTrue(schema.apply("id").nullable());
+  }
+
+  @Test
+  public void resultSetMetadataToSchemaConvertsArraysAndStructs() {
+    Type arrayType =
+        Type.newBuilder().setCode(TypeCode.ARRAY).setArrayElementType(type(TypeCode.INT64)).build();
+    Type structType =
+        Type.newBuilder()
+            .setCode(TypeCode.STRUCT)
+            .setStructType(
+                com.google.spanner.v1.StructType.newBuilder()
+                    .addFields(field("name", type(TypeCode.STRING)))
+                    .addFields(field("count", type(TypeCode.INT64))))
+            .build();
+
+    StructType schema =
+        SpannerQueryTable.resultSetMetadataToSchema(
+            metadata(field("values", arrayType), field("details", structType)));
+
+    assertEquals(
+        DataTypes.createArrayType(DataTypes.LongType, true), schema.apply("values").dataType());
+    StructType details = (StructType) schema.apply("details").dataType();
+    assertEquals(DataTypes.StringType, details.apply("name").dataType());
+    assertEquals(DataTypes.LongType, details.apply("count").dataType());
+  }
+
+  @Test
+  public void resultSetMetadataToSchemaPreservesJsonAnnotations() {
+    Type jsonbType =
+        Type.newBuilder()
+            .setCode(TypeCode.JSON)
+            .setTypeAnnotation(TypeAnnotationCode.PG_JSONB)
+            .build();
+    StructType schema =
+        SpannerQueryTable.resultSetMetadataToSchema(
+            metadata(field("json", type(TypeCode.JSON)), field("jsonb", jsonbType)));
+
+    assertEquals("json", schema.apply("json").metadata().getString(SpannerUtils.COLUMN_TYPE));
+    assertEquals("jsonb", schema.apply("jsonb").metadata().getString(SpannerUtils.COLUMN_TYPE));
+  }
+
+  @Test
+  public void resultSetMetadataToSchemaRejectsUnnamedColumns() {
+    SpannerConnectorException error =
+        assertThrows(
+            SpannerConnectorException.class,
+            () ->
+                SpannerQueryTable.resultSetMetadataToSchema(
+                    metadata(field("", type(TypeCode.INT64)))));
+
+    assertTrue(error.getMessage().contains("alias"));
+  }
+
+  @Test
+  public void resultSetMetadataToSchemaRejectsDuplicateColumnsCaseInsensitively() {
+    SpannerConnectorException error =
+        assertThrows(
+            SpannerConnectorException.class,
+            () ->
+                SpannerQueryTable.resultSetMetadataToSchema(
+                    metadata(
+                        field("id", type(TypeCode.INT64)), field("ID", type(TypeCode.INT64)))));
+
+    assertTrue(error.getMessage().contains("Duplicate"));
+  }
+
+  @Test
+  public void resultSetMetadataToSchemaRejectsUnsupportedTypes() {
+    SpannerConnectorException error =
+        assertThrows(
+            SpannerConnectorException.class,
+            () ->
+                SpannerQueryTable.resultSetMetadataToSchema(
+                    metadata(field("value", type(TypeCode.PROTO)))));
+
+    assertEquals(SpannerErrorCode.UNSUPPORTED_DATATYPE, error.getErrorCode());
+  }
+
+  private static ResultSetMetadata metadata(com.google.spanner.v1.StructType.Field... fields) {
+    com.google.spanner.v1.StructType.Builder rowType =
+        com.google.spanner.v1.StructType.newBuilder();
+    for (com.google.spanner.v1.StructType.Field field : fields) {
+      rowType.addFields(field);
+    }
+    return ResultSetMetadata.newBuilder().setRowType(rowType).build();
+  }
+
+  private static com.google.spanner.v1.StructType.Field field(String name, Type type) {
+    return com.google.spanner.v1.StructType.Field.newBuilder().setName(name).setType(type).build();
+  }
+
+  private static Type type(TypeCode code) {
+    return Type.newBuilder().setCode(code).build();
+  }
+}


### PR DESCRIPTION
Spark callers currently need a physical table or graph source even when the desired Spanner query is already root-partitionable. That prevents directly expressing server-side filtering and projection as a Spark DataFrame source.

Add a `query` read option that discovers its result schema from Spanner metadata and reuses the connector's existing distributed partition readers and snapshot options. Keep table reads unchanged, reject ambiguous `table` plus `query` configuration, and document the new usage.